### PR TITLE
Fix graceful shutdown when MCP client disconnects

### DIFF
--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -536,7 +536,7 @@ async def handle_call_tool(
 async def main():
     """Main entry point for the server."""
     global use_tcp_mode, tcp_host, tcp_port
-    
+
     parser = argparse.ArgumentParser(description="Rocq MCP Server")
     parser.add_argument(
         "--host", default="127.0.0.1", help="Petanque server host for TCP mode (default: 127.0.0.1)"
@@ -559,25 +559,65 @@ async def main():
         use_tcp_mode = False
         logger.info("Using stdio mode (default)")
 
-    # Run the MCP server
-    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            InitializationOptions(
-                server_name="rocq-mcp",
-                server_version="0.1.0",
-                capabilities=server.get_capabilities(
-                    notification_options=NotificationOptions(),
-                    experimental_capabilities={},
+    # Run the MCP server with proper error handling for pipe closure
+    try:
+        async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                InitializationOptions(
+                    server_name="rocq-mcp",
+                    server_version="0.1.0",
+                    capabilities=server.get_capabilities(
+                        notification_options=NotificationOptions(),
+                        experimental_capabilities={},
+                    ),
                 ),
-            ),
-        )
+            )
+    except BrokenPipeError:
+        logger.info("Pipe closed by client, shutting down gracefully...")
+    except ConnectionResetError:
+        logger.info("Connection reset by client, shutting down gracefully...")
+    except Exception as e:
+        if "Broken pipe" in str(e) or "EOF" in str(e):
+            logger.info("Client disconnected, shutting down gracefully...")
+        else:
+            logger.error(f"Server error: {e}", exc_info=True)
+    finally:
+        # Clean up petanque process if running
+        cleanup_petanque_process()
+        logger.info("rocq-mcp server exiting")
 
 
 def cli():
     """CLI entry point for Poetry script."""
-    asyncio.run(main())
+    # Handle SIGHUP (parent process died) for graceful shutdown
+    def sighup_handler(signum, frame):
+        logger.info("Received SIGHUP (parent died), shutting down...")
+        cleanup_petanque_process()
+        sys.exit(0)
+
+    # Handle SIGPIPE (broken pipe) for graceful shutdown
+    def sigpipe_handler(signum, frame):
+        logger.info("Received SIGPIPE, shutting down...")
+        cleanup_petanque_process()
+        sys.exit(0)
+
+    try:
+        signal.signal(signal.SIGHUP, sighup_handler)
+        signal.signal(signal.SIGPIPE, sigpipe_handler)
+    except (ValueError, OSError):
+        # Signal handling may fail in some environments
+        pass
+
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Interrupted, shutting down...")
+    except BrokenPipeError:
+        logger.info("Pipe closed, shutting down...")
+    finally:
+        cleanup_petanque_process()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a vibe coded solution to https://github.com/LLM4Rocq/rocq-mcp/issues/4
----

When the MCP client (e.g., Claude Code) disconnects or its session ends, the rocq-mcp server process would continue running as an orphan because it didn't detect the closed stdin pipe. This caused "Broken pipe" errors on subsequent sessions since the old process was still bound.

This fix adds proper handling for pipe closure:

1. Exception handling in main():
   - Catches BrokenPipeError and ConnectionResetError
   - Catches generic exceptions with "Broken pipe" or "EOF" in message
   - Always runs cleanup in finally block

2. Signal handlers in cli():
   - SIGHUP handler - triggered when parent process dies
   - SIGPIPE handler - triggered when writing to closed pipe
   - Both call cleanup_petanque_process() and exit gracefully

3. Top-level exception handling in cli():
   - Catches KeyboardInterrupt and BrokenPipeError
   - Ensures cleanup runs in all cases