### PR TITLE
Add .mcp-workspace/ directory support for project flags

### DIFF
--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -169,6 +169,16 @@ def _parse_project_flags(ws: Path) -> list[str]:
     - Directory paths in ``-Q``/``-R``/``-I`` are validated to stay
       within the workspace (absolute paths and ``../`` escapes rejected).
     """
+    # Prefer .mcp-workspace/ subdirectory if it contains a project file.
+    # This allows projects to maintain a separate _CoqProject for MCP/coq-lsp
+    # without modifying the main build's _CoqProject.
+    mcp_ws = ws / ".mcp-workspace"
+    for name in ("_RocqProject", "_CoqProject"):
+        p = mcp_ws / name
+        if p.is_file():
+            ws = mcp_ws  # redirect to the MCP workspace
+            break
+
     for name in ("_RocqProject", "_CoqProject"):
         proj = ws / name
         if proj.is_file():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -455,6 +455,49 @@ class TestParseProjectFlags:
         flags = _parse_project_flags(tmp_path)
         assert flags == []
 
+    # --- .mcp-workspace/ directory support ---
+
+    def test_mcp_workspace_coqproject_preferred(self, tmp_path):
+        """.mcp-workspace/_CoqProject is preferred over root _CoqProject."""
+        (tmp_path / "_CoqProject").write_text("-Q . RootProject\n")
+        mcp_ws = tmp_path / ".mcp-workspace"
+        mcp_ws.mkdir()
+        (mcp_ws / "_CoqProject").write_text("-Q . McpProject\n")
+        flags = _parse_project_flags(tmp_path)
+        assert flags == ["-Q", ".", "McpProject"]
+
+    def test_mcp_workspace_rocqproject_preferred(self, tmp_path):
+        """.mcp-workspace/_RocqProject is preferred over root _RocqProject."""
+        (tmp_path / "_RocqProject").write_text("-Q . RootProject\n")
+        mcp_ws = tmp_path / ".mcp-workspace"
+        mcp_ws.mkdir()
+        (mcp_ws / "_RocqProject").write_text("-Q . McpProject\n")
+        flags = _parse_project_flags(tmp_path)
+        assert flags == ["-Q", ".", "McpProject"]
+
+    def test_mcp_workspace_missing_falls_back(self, tmp_path):
+        """Without .mcp-workspace/, falls back to root _CoqProject."""
+        (tmp_path / "_CoqProject").write_text("-Q . RootProject\n")
+        flags = _parse_project_flags(tmp_path)
+        assert flags == ["-Q", ".", "RootProject"]
+
+    def test_mcp_workspace_empty_falls_back(self, tmp_path):
+        """.mcp-workspace/ exists but has no project file -> root _CoqProject."""
+        (tmp_path / "_CoqProject").write_text("-Q . RootProject\n")
+        mcp_ws = tmp_path / ".mcp-workspace"
+        mcp_ws.mkdir()
+        flags = _parse_project_flags(tmp_path)
+        assert flags == ["-Q", ".", "RootProject"]
+
+    def test_mcp_workspace_rocqproject_over_root_coqproject(self, tmp_path):
+        """.mcp-workspace/_RocqProject beats root _CoqProject."""
+        (tmp_path / "_CoqProject").write_text("-Q . RootCoq\n")
+        mcp_ws = tmp_path / ".mcp-workspace"
+        mcp_ws.mkdir()
+        (mcp_ws / "_RocqProject").write_text("-Q . McpRocq\n")
+        flags = _parse_project_flags(tmp_path)
+        assert flags == ["-Q", ".", "McpRocq"]
+
 
 # =========================================================================
 # _force_release_pet_lock — deadlock recovery


### PR DESCRIPTION
## Summary

- When `_parse_project_flags` looks for `_RocqProject`/`_CoqProject`, prefer a `.mcp-workspace/` subdirectory if it exists
- This allows projects to maintain a separate `_CoqProject` for MCP/coq-lsp without modifying the main build's `_CoqProject` (which may reference submodules with incompatible `.vo` files compiled by a different Rocq version)

## Motivation

Projects like fiat-crypto have a `_CoqProject` that references submodules whose `.vo` files are compiled by a different Rocq version than the one coq-lsp uses. Creating `.mcp-workspace/_CoqProject` with only the compatible load paths lets MCP work without touching the main build configuration.

## Test plan

- [x] 5 new tests in `test_server.py` covering: preference over root, fallback when missing, fallback when empty, `_RocqProject` variant
- [x] All 617 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)