### PR TITLE
Add feedback field and result truncation to rocq_check

### DIFF
--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -48,6 +48,20 @@ from rocq_mcp.compile import _split_rocq_sentences
 
 _MAX_GOALS_LENGTH: int = 8000  # Max chars for formatted goals output
 _MAX_GOALS_SHOWN: int = 10  # Max number of goals to format
+_MAX_FEEDBACK_LENGTH: int = 50_000  # Max chars for feedback in run_check responses
+
+
+def _truncate_result(text: str, max_length: int) -> str:
+    """Truncate *text* to *max_length* chars, appending a notice if trimmed.
+
+    This prevents token explosions when tactics like ``vm_compute`` or
+    ``native_compute`` produce enormous output (up to 6.5 M chars observed).
+    The truncation notice includes the original length so the caller knows
+    how much was dropped.
+    """
+    if len(text) <= max_length:
+        return text
+    return text[:max_length] + f"\n... (truncated, {len(text)} total chars)"
 
 
 def _format_goals(goals_list: list[Any]) -> str:
@@ -941,6 +955,7 @@ async def run_check(
 
         state = entry_to_use.state
         prev_state_id = base_state_id
+        feedback_parts: list[str] = []  # Collect feedback from each step
 
         for i, cmd in enumerate(commands):
             try:
@@ -955,6 +970,14 @@ async def run_check(
                     rocq_timeout = None
 
                 new_state = pet.run(state, cmd, timeout=rocq_timeout)
+
+                # Collect any feedback (e.g. from vm_compute, native_compute,
+                # or Print/Check commands that produce output).
+                step_feedback = getattr(new_state, "feedback", None) or []
+                for _, msg in step_feedback:
+                    if msg:
+                        feedback_parts.append(msg)
+
                 state_id = _state_add(
                     state=new_state,
                     file=entry_to_use.file,
@@ -1014,6 +1037,12 @@ async def run_check(
             "state_id": prev_state_id,
             "parent_state_id": base_state_id,
         }
+        # Include feedback (truncated) when present
+        if feedback_parts:
+            raw_feedback = "\n".join(feedback_parts)
+            result["feedback"] = _truncate_result(
+                raw_feedback, _MAX_FEEDBACK_LENGTH
+            )
         if stale_warning:
             result["stale_warning"] = stale_warning
         if complete and complete.shelf:

--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -1040,9 +1040,7 @@ async def run_check(
         # Include feedback (truncated) when present
         if feedback_parts:
             raw_feedback = "\n".join(feedback_parts)
-            result["feedback"] = _truncate_result(
-                raw_feedback, _MAX_FEEDBACK_LENGTH
-            )
+            result["feedback"] = _truncate_result(raw_feedback, _MAX_FEEDBACK_LENGTH)
         if stale_warning:
             result["stale_warning"] = stale_warning
         if complete and complete.shelf:

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -1,0 +1,51 @@
+"""Tests for _truncate_result utility and feedback collection in run_check."""
+
+from __future__ import annotations
+
+from rocq_mcp.interactive import _truncate_result, _MAX_FEEDBACK_LENGTH
+
+
+class TestTruncateResult:
+    """Unit tests for _truncate_result."""
+
+    def test_short_text_unchanged(self):
+        """Text shorter than max_length passes through unchanged."""
+        text = "hello world"
+        assert _truncate_result(text, 100) == text
+
+    def test_exact_length_unchanged(self):
+        """Text exactly at max_length passes through unchanged."""
+        text = "x" * 50
+        assert _truncate_result(text, 50) == text
+
+    def test_over_limit_truncated(self):
+        """Text exceeding max_length is truncated with notice."""
+        text = "a" * 200
+        result = _truncate_result(text, 100)
+        assert result.startswith("a" * 100)
+        assert "truncated" in result
+        assert "200 total chars" in result
+
+    def test_truncation_preserves_prefix(self):
+        """The first max_length chars of the original are preserved."""
+        text = "ABCDE" + "x" * 1000
+        result = _truncate_result(text, 5)
+        assert result.startswith("ABCDE")
+        assert "truncated" in result
+
+    def test_empty_string(self):
+        """Empty string passes through unchanged."""
+        assert _truncate_result("", 100) == ""
+
+    def test_large_vm_compute_style_output(self):
+        """Simulates large vm_compute output (the motivating use case)."""
+        # vm_compute can produce megabytes of output
+        huge = "0" * 6_500_000  # 6.5M chars
+        result = _truncate_result(huge, _MAX_FEEDBACK_LENGTH)
+        assert len(result) < _MAX_FEEDBACK_LENGTH + 200  # room for notice
+        assert result.startswith("0" * _MAX_FEEDBACK_LENGTH)
+        assert "6500000 total chars" in result
+
+    def test_max_feedback_length_constant(self):
+        """Verify the constant is set to the expected value."""
+        assert _MAX_FEEDBACK_LENGTH == 50_000


### PR DESCRIPTION
## Summary

- Add `_MAX_FEEDBACK_LENGTH = 50_000` constant and `_truncate_result()` utility for capping large output
- Collect `state.feedback` from each `pet.run()` call in `run_check` and include it (truncated) in the response as a `"feedback"` field
- Prevents token explosions when tactics like `vm_compute` or `native_compute` produce enormous output (up to 6.5M chars observed in production)

## Motivation

In production use with fiat-crypto BLS proofs, `vm_compute` and `native_compute` on large goals produced outputs up to 6.5M characters. Without truncation, these overwhelm the LLM's context window (252 "exceeds max tokens" events observed). The existing `_MAX_GOALS_LENGTH` and `_MAX_QUERY_OUTPUT` limits don't cover feedback from tactic execution in `rocq_check`.

## Test plan

- [x] 7 new tests in `test_truncate.py` covering: short text unchanged, exact-length unchanged, over-limit truncated, prefix preserved, empty string, 6.5M simulation
- [x] All 623 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)