### PR TITLE
Add proof reconstruction for Admitted/Section-local theorems

### DIFF
--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -131,7 +131,9 @@ def _reconstruct_proof_state(
         logger.info("Reconstruction: trying start('%s')", thm_name)
         start_state = pet.start(file_path, thm_name)
         if getattr(start_state, "proof_finished", False):
-            logger.info("Reconstruction: start() returned proof_finished, trying strategy 2")
+            logger.info(
+                "Reconstruction: start() returned proof_finished, trying strategy 2"
+            )
             start_state = None
     except Exception as e:
         logger.info("Reconstruction: start() failed (%s), trying strategy 2", e)
@@ -149,7 +151,9 @@ def _reconstruct_proof_state(
             logger.info("Reconstruction: getting state at line %d", first_require)
             base_state = pet.get_state_at_pos(file_path, first_require, 0)
 
-            replay_text = "".join(file_lines[first_require : proof_start_line + 1]).strip()
+            replay_text = "".join(
+                file_lines[first_require : proof_start_line + 1]
+            ).strip()
             if not replay_text.rstrip().endswith("Proof."):
                 replay_text += "\nProof."
 
@@ -169,7 +173,7 @@ def _reconstruct_proof_state(
 
     # --- Replay tactics from Proof. to cursor ---
     replay_start = proof_start_line + 1
-    tactic_text = "".join(file_lines[replay_start : cursor_line]).strip()
+    tactic_text = "".join(file_lines[replay_start:cursor_line]).strip()
 
     # Strip comments and proof terminators
     tactic_text = re.sub(r"\(\*.*?\*\)", "", tactic_text, flags=re.DOTALL)
@@ -182,7 +186,9 @@ def _reconstruct_proof_state(
         try:
             current = pet.run(current, tactic_text)
         except Exception:
-            logger.info("Reconstruction: block replay failed, trying sentence-by-sentence")
+            logger.info(
+                "Reconstruction: block replay failed, trying sentence-by-sentence"
+            )
             current = start_state
             sentences = re.split(r"\.(?=\s|$)", tactic_text)
             for sent in sentences:

--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -22,6 +22,7 @@ Infrastructure:
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import re
 import tempfile
@@ -41,6 +42,163 @@ import rocq_mcp.server as _server
 
 # _split_rocq_sentences is in compile — import directly (no cycle).
 from rocq_mcp.compile import _split_rocq_sentences
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Proof reconstruction for Admitted / Section-local theorems
+# ---------------------------------------------------------------------------
+
+# Keywords that start a proof-bearing declaration
+_PROOF_DECL_KEYWORDS = (
+    "Lemma ",
+    "Theorem ",
+    "Definition ",
+    "Instance ",
+    "Local Lemma ",
+    "Local Theorem ",
+    "Local Definition ",
+    "Local Instance ",
+    "Global Instance ",
+    "Program Lemma ",
+    "Program Definition ",
+)
+
+_LEMMA_RE = re.compile(
+    r"(?:Local\s+|Global\s+|Program\s+)?"
+    r"(?:Lemma|Theorem|Definition|Instance)\s+"
+    r"(\w+)"
+)
+
+
+def _reconstruct_proof_state(
+    pet: Any, file_path: str, cursor_line: int, cursor_char: int
+) -> tuple[Any | None, str]:
+    """Reconstruct an open proof state when get_state_at_pos returns proof_finished.
+
+    When the cursor is inside an Admitted proof, get_state_at_pos treats the
+    theorem as finished.  This function opens the proof interactively so the
+    user can develop a replacement proof.
+
+    Strategy:
+      1. Search backwards for the enclosing Lemma/Theorem and ``Proof.``.
+      2. Try ``pet.start(file, thm_name)`` (works for top-level theorems).
+      3. Fall back to replaying imports + Section preamble from the file start
+         through ``Proof.`` (works for Section-local theorems).
+      4. Replay tactics from ``Proof.`` to the cursor position.
+
+    Returns ``(state, info_message)`` on success or ``(None, error_message)``
+    on failure.
+    """
+    try:
+        with open(file_path, "r") as f:
+            file_lines = f.readlines()
+    except OSError as e:
+        return None, f"Cannot read file: {e}"
+
+    # --- Locate enclosing declaration and Proof. line ---
+    proof_start_line: int | None = None
+    lemma_line: int | None = None
+    thm_name: str | None = None
+
+    for i in range(min(cursor_line, len(file_lines) - 1), -1, -1):
+        stripped = file_lines[i].strip()
+        if stripped.startswith("Proof"):
+            proof_start_line = i
+        if any(stripped.startswith(kw) for kw in _PROOF_DECL_KEYWORDS):
+            lemma_line = i
+            m = _LEMMA_RE.match(stripped)
+            if m:
+                thm_name = m.group(1)
+            break
+
+    # If Proof not found backwards, search forward from the Lemma line
+    if lemma_line is not None and proof_start_line is None:
+        for i in range(lemma_line, min(cursor_line + 5, len(file_lines))):
+            if "Proof" in file_lines[i].strip():
+                proof_start_line = i
+                break
+
+    if not (lemma_line is not None and proof_start_line is not None and thm_name):
+        return None, (
+            f"Could not locate lemma/proof/name "
+            f"(lemma={lemma_line}, proof={proof_start_line}, name={thm_name})"
+        )
+
+    # --- Strategy 1: pet.start(thm_name) ---
+    start_state = None
+    try:
+        logger.info("Reconstruction: trying start('%s')", thm_name)
+        start_state = pet.start(file_path, thm_name)
+        if getattr(start_state, "proof_finished", False):
+            logger.info("Reconstruction: start() returned proof_finished, trying strategy 2")
+            start_state = None
+    except Exception as e:
+        logger.info("Reconstruction: start() failed (%s), trying strategy 2", e)
+
+    # --- Strategy 2: replay from first Require through Proof. ---
+    if start_state is None:
+        try:
+            first_require = 0
+            for i in range(len(file_lines)):
+                s = file_lines[i].strip()
+                if s.startswith("Require") or s.startswith("From "):
+                    first_require = i
+                    break
+
+            logger.info("Reconstruction: getting state at line %d", first_require)
+            base_state = pet.get_state_at_pos(file_path, first_require, 0)
+
+            replay_text = "".join(file_lines[first_require : proof_start_line + 1]).strip()
+            if not replay_text.rstrip().endswith("Proof."):
+                replay_text += "\nProof."
+
+            logger.info(
+                "Reconstruction: replaying %d lines from file start",
+                proof_start_line + 1 - first_require,
+            )
+            start_state = pet.run(base_state, replay_text)
+
+            if getattr(start_state, "proof_finished", False):
+                return None, "Section replay returned proof_finished"
+        except Exception as e:
+            return None, f"Section replay failed: {e}"
+
+    if start_state is None:
+        return None, "Both reconstruction strategies failed"
+
+    # --- Replay tactics from Proof. to cursor ---
+    replay_start = proof_start_line + 1
+    tactic_text = "".join(file_lines[replay_start : cursor_line]).strip()
+
+    # Strip comments and proof terminators
+    tactic_text = re.sub(r"\(\*.*?\*\)", "", tactic_text, flags=re.DOTALL)
+    for term in ("Admitted.", "Qed.", "Abort.", "Defined."):
+        tactic_text = tactic_text.replace(term, "")
+    tactic_text = tactic_text.strip()
+
+    current = start_state
+    if tactic_text:
+        try:
+            current = pet.run(current, tactic_text)
+        except Exception:
+            logger.info("Reconstruction: block replay failed, trying sentence-by-sentence")
+            current = start_state
+            sentences = re.split(r"\.(?=\s|$)", tactic_text)
+            for sent in sentences:
+                sent = sent.strip()
+                if not sent:
+                    continue
+                try:
+                    current = pet.run(current, sent + ".")
+                except Exception as e:
+                    logger.info("Reconstruction: stopped at: %.60s (%s)", sent, e)
+                    break
+
+    info = f"Reconstructed via '{thm_name}', replay lines {replay_start}-{cursor_line}"
+    logger.info("Reconstruction: success — %s", info)
+    return current, info
+
 
 # ---------------------------------------------------------------------------
 # Goal formatting helper (shared by run_check, run_step_multi)
@@ -787,6 +945,20 @@ async def run_start(
         elif _start_by_pos:
             _server._set_workspace_if_needed(pet, workspace, lifespan_state)
             state = pet.get_state_at_pos(resolved_file, line, character)
+            proof_finished = getattr(state, "proof_finished", False)
+
+            # If proof_finished inside an Admitted proof, try to reconstruct
+            # an open proof state so the user can develop a replacement.
+            reconstructed_info = ""
+            if proof_finished:
+                rstate, rmsg = _reconstruct_proof_state(
+                    pet, resolved_file, line, character
+                )
+                if rstate is not None:
+                    state = rstate
+                    proof_finished = getattr(state, "proof_finished", False)
+                    reconstructed_info = rmsg
+
             # Capture mtime after get_state_at_pos to avoid TOCTOU gap
             try:
                 file_mtime = os.path.getmtime(resolved_file)
@@ -804,14 +976,17 @@ async def run_start(
                 resolved_file=resolved_file,
             )
             goals = _try_get_goals(pet, state) or ""
-            return {
+            result = {
                 "success": True,
                 "state_id": state_id,
                 "goals": goals,
                 "file": file,
                 "theorem": f"@pos({line},{character})",
-                "proof_finished": getattr(state, "proof_finished", False),
+                "proof_finished": proof_finished,
             }
+            if reconstructed_info:
+                result["reconstructed"] = reconstructed_info
+            return result
         else:
             # Preamble mode
             preamble_cmds = _split_rocq_sentences(preamble) if preamble.strip() else []

--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -214,8 +214,8 @@ Admitted.
         final_state = _make_state(proof_finished=False)
         pet.run.side_effect = [
             Exception("block fail"),  # block replay
-            mid_state,                # "idtac."
-            final_state,              # "exact I."
+            mid_state,  # "idtac."
+            final_state,  # "exact I."
         ]
 
         # cursor at line 3 (Admitted) — should replay "idtac. exact I."
@@ -437,8 +437,8 @@ class TestRunStartReconstruction(_MockPetBase):
 
         finished = SimpleNamespace(st=50, proof_finished=True, feedback=[])
         mock_pet.get_state_at_pos.side_effect = [
-            finished,                       # run_start call
-            Exception("approach 2 fail"),   # reconstruction approach 2
+            finished,  # run_start call
+            Exception("approach 2 fail"),  # reconstruction approach 2
         ]
         mock_pet.start.side_effect = Exception("approach 1 fail")
         mock_pet.complete_goals.return_value = SimpleNamespace(
@@ -455,8 +455,7 @@ class TestRunStartReconstruction(_MockPetBase):
             vfile = os.path.join(ws, "test.v")
             with open(vfile, "w") as f:
                 f.write(
-                    "Require Import Arith.\n"
-                    "Lemma foo : True.\nProof.\nAdmitted.\n"
+                    "Require Import Arith.\n" "Lemma foo : True.\nProof.\nAdmitted.\n"
                 )
 
             with patch.object(rocq_mcp.server, "_ensure_pet", return_value=mock_pet):

--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -1,0 +1,474 @@
+"""Tests for proof reconstruction of Admitted / Section-local theorems."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rocq_mcp.interactive import _reconstruct_proof_state
+
+
+def _make_state(proof_finished: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(proof_finished=proof_finished)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_v_file(content: str) -> str:
+    """Write *content* to a temp .v file and return its path."""
+    f = tempfile.NamedTemporaryFile(suffix=".v", mode="w", delete=False)
+    f.write(textwrap.dedent(content))
+    f.close()
+    return f.name
+
+
+# ---------------------------------------------------------------------------
+# Strategy 1: pet.start(thm_name) succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestReconstructionStrategy1:
+    """pet.start() works for top-level theorems."""
+
+    def test_basic_reconstruction(self):
+        # Lines: 0=From, 1=Lemma, 2=Proof., 3=intros, 4=Admitted.
+        path = _write_v_file("""\
+From Stdlib Require Import Arith.
+Lemma add_0_r : forall n, n + 0 = n.
+Proof.
+  intros n.
+Admitted.
+""")
+        pet = MagicMock()
+        open_state = _make_state(proof_finished=False)
+        # pet.start returns an open proof state
+        pet.start.return_value = open_state
+        # pet.run replays tactics and returns a new state
+        pet.run.return_value = _make_state(proof_finished=False)
+
+        # cursor at line 4 (Admitted line) — replay should include "intros n."
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=4, cursor_char=0)
+
+        assert state is not None
+        assert not state.proof_finished
+        pet.start.assert_called_once_with(path, "add_0_r")
+        # run() called once to replay "intros n."
+        assert pet.run.call_count == 1
+
+    def test_cursor_at_proof_start(self):
+        """Cursor right after Proof. — no tactics to replay."""
+        # Lines: 0=Theorem, 1=Proof., 2=Admitted.
+        path = _write_v_file("""\
+Theorem foo : True.
+Proof.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.return_value = _make_state(proof_finished=False)
+
+        # cursor at line 2 (Admitted) — replay_start=2, cursor=2, so no tactics
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=2, cursor_char=0)
+
+        assert state is not None
+        # No run() call needed since no tactics between Proof. and cursor
+        pet.run.assert_not_called()
+
+    def test_start_returns_finished_falls_to_strategy2(self):
+        """pet.start returns proof_finished → fall to strategy 2."""
+        # Lines: 0=From, 1=Lemma, 2=Proof., 3=Admitted.
+        path = _write_v_file("""\
+From Stdlib Require Import Arith.
+Lemma bar : True.
+Proof.
+Admitted.
+""")
+        pet = MagicMock()
+        # Strategy 1 returns finished
+        pet.start.return_value = _make_state(proof_finished=True)
+        # Strategy 2 calls
+        replay_state = _make_state(proof_finished=False)
+        pet.get_state_at_pos.return_value = _make_state(proof_finished=False)
+        pet.run.return_value = replay_state
+
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=3, cursor_char=0)
+
+        assert state is not None
+        pet.get_state_at_pos.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Strategy 2: Section-local theorem (pet.start fails)
+# ---------------------------------------------------------------------------
+
+
+class TestReconstructionStrategy2:
+    """Fallback: replay from file start."""
+
+    def test_section_local(self):
+        # Lines: 0=From, 1=Section, 2=Variable, 3=Lemma, 4=Proof., 5=reflexivity, 6=Admitted.
+        path = _write_v_file("""\
+From Stdlib Require Import Arith.
+Section Foo.
+Variable x : nat.
+Lemma bar : x = x.
+Proof.
+  reflexivity.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.side_effect = Exception("Section-local, cannot start")
+        base_state = _make_state(proof_finished=False)
+        pet.get_state_at_pos.return_value = base_state
+        after_replay = _make_state(proof_finished=False)
+        # First run: replay preamble; second run: replay tactics
+        pet.run.side_effect = [after_replay, _make_state(proof_finished=False)]
+
+        # cursor at line 6 (Admitted) — replay includes "reflexivity."
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=6, cursor_char=0)
+
+        assert state is not None
+        # get_state_at_pos called for base state
+        pet.get_state_at_pos.assert_called_once()
+        # run called: once for preamble, once for tactic replay
+        assert pet.run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestReconstructionEdgeCases:
+    def test_no_lemma_found(self):
+        path = _write_v_file("""\
+(* just a comment *)
+""")
+        pet = MagicMock()
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=0, cursor_char=0)
+        assert state is None
+        assert "Could not locate" in msg
+
+    def test_file_not_found(self):
+        pet = MagicMock()
+        state, msg = _reconstruct_proof_state(pet, "/nonexistent.v", 0, 0)
+        assert state is None
+        assert "Cannot read file" in msg
+
+    def test_local_lemma_keyword(self):
+        """Local Lemma is recognized."""
+        # Lines: 0=Section, 1=Local Lemma, 2=Proof., 3=Admitted.
+        path = _write_v_file("""\
+Section S.
+Local Lemma foo : True.
+Proof.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.return_value = _make_state(proof_finished=False)
+
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=3, cursor_char=0)
+
+        assert state is not None
+        pet.start.assert_called_once_with(path, "foo")
+
+    def test_both_strategies_fail(self):
+        # Lines: 0=Lemma, 1=Proof., 2=Admitted.
+        path = _write_v_file("""\
+Lemma bad : True.
+Proof.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.side_effect = Exception("fail")
+        pet.get_state_at_pos.return_value = _make_state(proof_finished=False)
+        pet.run.side_effect = Exception("replay fail")
+
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=2, cursor_char=0)
+
+        assert state is None
+        assert "failed" in msg.lower()
+
+    def test_sentence_by_sentence_fallback(self):
+        """When block replay fails, falls back to sentence-by-sentence."""
+        # Lines: 0=Lemma, 1=Proof., 2=idtac. exact I., 3=Admitted.
+        path = _write_v_file("""\
+Lemma baz : True.
+Proof.
+  idtac. exact I.
+Admitted.
+""")
+        pet = MagicMock()
+        open_state = _make_state(proof_finished=False)
+        pet.start.return_value = open_state
+        # Block replay fails, sentence-by-sentence succeeds
+        mid_state = _make_state(proof_finished=False)
+        final_state = _make_state(proof_finished=False)
+        pet.run.side_effect = [
+            Exception("block fail"),  # block replay
+            mid_state,                # "idtac."
+            final_state,              # "exact I."
+        ]
+
+        # cursor at line 3 (Admitted) — should replay "idtac. exact I."
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=3, cursor_char=0)
+
+        assert state is not None
+        # run called: 1 (block fail) + 2 (sentences)
+        assert pet.run.call_count == 3
+
+    def test_comments_and_terminators_stripped(self):
+        """Comments and Admitted/Qed are removed before replay."""
+        path = _write_v_file("""\
+Theorem foo : True.
+Proof.
+  (* a comment *) exact I.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.return_value = _make_state(proof_finished=False)
+        pet.run.return_value = _make_state(proof_finished=False)
+
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=3, cursor_char=0)
+
+        assert state is not None
+        # The replay text should NOT contain the comment or Admitted
+        replay_call = pet.run.call_args_list[0]
+        tactic_text = replay_call[0][1]
+        assert "(*" not in tactic_text
+        assert "Admitted" not in tactic_text
+
+    def test_program_definition_keyword(self):
+        """Program Definition is recognized."""
+        path = _write_v_file("""\
+Program Definition my_prog : nat.
+Proof.
+  exact 0.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.return_value = _make_state(proof_finished=False)
+
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=3, cursor_char=0)
+        assert state is not None
+        pet.start.assert_called_once_with(path, "my_prog")
+
+    def test_global_instance_keyword(self):
+        """Global Instance is recognized."""
+        path = _write_v_file("""\
+Global Instance my_inst : True.
+Proof.
+  exact I.
+Admitted.
+""")
+        pet = MagicMock()
+        pet.start.return_value = _make_state(proof_finished=False)
+
+        state, msg = _reconstruct_proof_state(pet, path, cursor_line=3, cursor_char=0)
+        assert state is not None
+        pet.start.assert_called_once_with(path, "my_inst")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: run_start position mode triggers reconstruction
+# ---------------------------------------------------------------------------
+
+
+class _MockPetBase:
+    """Shared setup for mock-based tests (no real pet)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state_and_semaphore(self):
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import _state_invalidate_all
+
+        _state_invalidate_all()
+        srv._pet_semaphore = None
+        yield
+        _state_invalidate_all()
+        srv._pet_semaphore = None
+
+    @pytest.fixture(autouse=True)
+    def _mock_pytanque(self):
+        """Ensure pytanque is importable even if not installed."""
+        import sys
+
+        if "pytanque" in sys.modules:
+            yield
+            return
+
+        mock_module = SimpleNamespace(
+            PetanqueError=type("PetanqueError", (Exception,), {"message": ""}),
+            Pytanque=MagicMock,
+            PytanqueMode=SimpleNamespace(STDIO="stdio"),
+        )
+        sys.modules["pytanque"] = mock_module
+        yield
+        sys.modules.pop("pytanque", None)
+
+
+class TestRunStartReconstruction(_MockPetBase):
+    """Integration: run_start in position mode calls reconstruction when needed."""
+
+    @pytest.mark.asyncio
+    async def test_proof_finished_triggers_reconstruction(self):
+        """When get_state_at_pos returns proof_finished=True, reconstruction runs."""
+        import os
+        from unittest.mock import patch
+
+        import rocq_mcp.server
+        import rocq_mcp.interactive as _interactive
+
+        mock_pet = MagicMock()
+        mock_pet.process = MagicMock()
+        mock_pet.process.poll.return_value = None
+        mock_pet._own_pgrp = False
+
+        # get_state_at_pos returns proof_finished=True (the trigger)
+        finished = SimpleNamespace(st=50, proof_finished=True, feedback=[])
+        mock_pet.get_state_at_pos.return_value = finished
+
+        # pet.start returns an open proof state (reconstruction succeeds)
+        open_state = SimpleNamespace(st=100, proof_finished=False, feedback=[])
+        mock_pet.start.return_value = open_state
+
+        mock_pet.complete_goals.return_value = SimpleNamespace(
+            goals=[], stack=[], shelf=[], given_up=[]
+        )
+
+        lifespan = {
+            "pet_client": mock_pet,
+            "pet_timeout": 30.0,
+            "current_workspace": "/tmp",
+        }
+
+        with tempfile.TemporaryDirectory() as ws:
+            vfile = os.path.join(ws, "test.v")
+            with open(vfile, "w") as f:
+                f.write(
+                    "Theorem my_thm : forall n : nat, n = n.\n"
+                    "Proof.\n"
+                    "  intros.\n"
+                    "Admitted.\n"
+                )
+
+            with patch.object(rocq_mcp.server, "_ensure_pet", return_value=mock_pet):
+                result = await _interactive.run_start(
+                    file="test.v",
+                    theorem="",
+                    workspace=ws,
+                    lifespan_state=lifespan,
+                    line=2,
+                    character=0,
+                )
+
+        assert result["success"] is True
+        assert result["proof_finished"] is False
+        # pet.start called by reconstruction
+        mock_pet.start.assert_called_once_with(os.path.join(ws, "test.v"), "my_thm")
+
+    @pytest.mark.asyncio
+    async def test_proof_not_finished_skips_reconstruction(self):
+        """When proof_finished=False, reconstruction does NOT run."""
+        import os
+        from unittest.mock import patch
+
+        import rocq_mcp.server
+        import rocq_mcp.interactive as _interactive
+
+        mock_pet = MagicMock()
+        mock_pet.process = MagicMock()
+        mock_pet.process.poll.return_value = None
+        mock_pet._own_pgrp = False
+
+        normal = SimpleNamespace(st=50, proof_finished=False, feedback=[])
+        mock_pet.get_state_at_pos.return_value = normal
+        mock_pet.complete_goals.return_value = SimpleNamespace(
+            goals=[], stack=[], shelf=[], given_up=[]
+        )
+
+        lifespan = {
+            "pet_client": mock_pet,
+            "pet_timeout": 30.0,
+            "current_workspace": "/tmp",
+        }
+
+        with tempfile.TemporaryDirectory() as ws:
+            vfile = os.path.join(ws, "test.v")
+            with open(vfile, "w") as f:
+                f.write("Theorem t : True.\nProof. exact I. Qed.\n")
+
+            with patch.object(rocq_mcp.server, "_ensure_pet", return_value=mock_pet):
+                result = await _interactive.run_start(
+                    file="test.v",
+                    theorem="",
+                    workspace=ws,
+                    lifespan_state=lifespan,
+                    line=1,
+                    character=0,
+                )
+
+        assert result["success"] is True
+        assert result["proof_finished"] is False
+        # reconstruction should NOT have been triggered
+        mock_pet.start.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconstruction_failure_keeps_original_state(self):
+        """When reconstruction fails, original (finished) state is kept."""
+        import os
+        from unittest.mock import patch
+
+        import rocq_mcp.server
+        import rocq_mcp.interactive as _interactive
+
+        mock_pet = MagicMock()
+        mock_pet.process = MagicMock()
+        mock_pet.process.poll.return_value = None
+        mock_pet._own_pgrp = False
+
+        finished = SimpleNamespace(st=50, proof_finished=True, feedback=[])
+        mock_pet.get_state_at_pos.side_effect = [
+            finished,                       # run_start call
+            Exception("approach 2 fail"),   # reconstruction approach 2
+        ]
+        mock_pet.start.side_effect = Exception("approach 1 fail")
+        mock_pet.complete_goals.return_value = SimpleNamespace(
+            goals=[], stack=[], shelf=[], given_up=[]
+        )
+
+        lifespan = {
+            "pet_client": mock_pet,
+            "pet_timeout": 30.0,
+            "current_workspace": "/tmp",
+        }
+
+        with tempfile.TemporaryDirectory() as ws:
+            vfile = os.path.join(ws, "test.v")
+            with open(vfile, "w") as f:
+                f.write(
+                    "Require Import Arith.\n"
+                    "Lemma foo : True.\nProof.\nAdmitted.\n"
+                )
+
+            with patch.object(rocq_mcp.server, "_ensure_pet", return_value=mock_pet):
+                result = await _interactive.run_start(
+                    file="test.v",
+                    theorem="",
+                    workspace=ws,
+                    lifespan_state=lifespan,
+                    line=3,
+                    character=0,
+                )
+
+        assert result["success"] is True
+        # Original state preserved
+        assert result["proof_finished"] is True


### PR DESCRIPTION
## Summary

- Add `_reconstruct_proof_state()` function to `interactive.py` that reconstructs an open proof state when `rocq_start` in position mode returns `proof_finished=True` inside an Admitted proof
- Hook it into `run_start`: when position mode detects `proof_finished=True`, attempt reconstruction before returning
- Two-strategy approach:
  1. `pet.start(thm_name)` for top-level theorems
  2. Replay from file start through Section preamble for Section-local theorems
- Replay tactics from `Proof.` to cursor position (block first, sentence-by-sentence fallback)

## Motivation

The most common use case for `rocq_start` in position mode is inspecting and proving `Admitted` theorems. Without this patch, `get_state_at_pos` returns `proof_finished=True` for any position inside an Admitted proof body, making interactive proving impossible. Users must manually remove `Admitted` from the file before they can work on the proof.

This is especially painful for Section-local theorems where `pet.start(thm_name)` also fails — the only way to get an open proof state is to replay the entire Section preamble.

## Test plan

- [x] 9 unit tests covering: basic reconstruction, cursor at proof start, strategy 1 → strategy 2 fallback, Section-local, no lemma found, file not found, Local Lemma keyword, both strategies fail, sentence-by-sentence fallback
- [x] Additional tests for comment/terminator stripping, Program Definition, Global Instance keywords
- [x] Integration tests for `run_start` position mode: trigger, skip, failure preservation
- [x] All 627 tests pass (612 upstream + 15 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)