### PR TITLE
Make timeout tests use a stable diverging tactic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,12 +132,7 @@ def timeout_proof():
     Uses a tactic that keeps growing the obligation without making
     progress.
     """
-    return (
-        "Theorem loop_thm : True.\n"
-        "Proof.\n"
-        "  repeat eapply proj1.\n"
-        "Qed.\n"
-    )
+    return "Theorem loop_thm : True.\n" "Proof.\n" "  repeat eapply proj1.\n" "Qed.\n"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,14 +129,13 @@ def admitted_proof():
 def timeout_proof():
     """A proof that loops forever, causing subprocess timeout.
 
-    Uses a recursive Ltac that truly diverges. The test must use a short
-    subprocess timeout (e.g. 3s) to trigger TimeoutExpired.
+    Uses a tactic that keeps growing the obligation without making
+    progress.
     """
     return (
-        "Ltac loop := idtac; loop.\n"
         "Theorem loop_thm : True.\n"
         "Proof.\n"
-        "  loop.\n"
+        "  repeat eapply proj1.\n"
         "Qed.\n"
     )
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -401,12 +401,7 @@ class TestCheckTimeout:
         from rocq_mcp.server import _invalidate_pet
 
         vfile = workspace / "check_timeout.v"
-        # Define the looping tactic but use a non-diverging proof body.
-        # coq-lsp processes the full file during pet.start(), so the file
-        # itself must not diverge. The loop is tested via run_check.
-        vfile.write_text(
-            "Ltac loop := idtac; loop.\n" "Theorem t : True.\nProof. exact I. Qed.\n"
-        )
+        vfile.write_text("Theorem t : True.\nProof. exact I. Qed.\n")
 
         # Use a normal timeout for start (pet compilation takes time),
         # then pass a short timeout explicitly to run_check.
@@ -421,7 +416,7 @@ class TestCheckTimeout:
             assert sr["success"] is True
 
             cr = await run_check(
-                body="loop.",
+                body="repeat eapply proj1.",
                 timeout=2.0,
                 lifespan_state=state,
                 from_state=sr["state_id"],


### PR DESCRIPTION
Running `loop` as currently used in the timeout tests terminates in around 1s on my machine, and hence the tests fail. This PR replaces the `loop` tactic with another, more robust diverging tactic from https://github.com/rocq-community/rocq-tricks/blob/main/src/Sleep.v .

