### PR TITLE
More informative error messages during rocq_compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The server exposes eleven MCP tools:
 
 | Tool | Description |
 |------|-------------|
-| **`rocq_compile`** | Batch-compile Rocq source code via coqc. Best for checking a finished proof. On error, returns error positions for jumping to interactive mode. For iterative development, prefer `rocq_check`. |
-| **`rocq_compile_file`** | Like `rocq_compile` but takes a file path instead of source string. More efficient for large files (avoids transmitting full source over MCP). Cleans up compilation artifacts but preserves the source file. |
+| **`rocq_compile`** | Batch-compile Rocq source code via coqc. Best for checking a finished proof. On error, returns error positions for jumping to interactive mode. When `pet`/coq-lsp is available in the MCP session, also includes the current proof state at the error position. For iterative development, prefer `rocq_check`. |
+| **`rocq_compile_file`** | Like `rocq_compile` but takes a file path instead of source string. More efficient for large files (avoids transmitting full source over MCP). Cleans up compilation artifacts but preserves the source file. When `pet`/coq-lsp is available in the MCP session, compile failures also include the current proof state at the error position. |
 | **`rocq_verify`** | Verify that a proof actually proves the original statement. Wraps in a `Module M.` sandbox to catch type redefinition, `Admitted`/`Abort`, custom axioms, and statement mismatches. Run after `rocq_compile` succeeds. |
 
 ### Interactive tools (pytanque-based, require `pet`)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The server exposes eleven MCP tools:
 
 | Tool | Description |
 |------|-------------|
-| **`rocq_compile`** | Batch-compile Rocq source code via coqc. Best for checking a finished proof. On error, returns error positions for jumping to interactive mode. When `pet`/coq-lsp is available in the MCP session, also includes the current proof state at the error position. For iterative development, prefer `rocq_check`. |
-| **`rocq_compile_file`** | Like `rocq_compile` but takes a file path instead of source string. More efficient for large files (avoids transmitting full source over MCP). Cleans up compilation artifacts but preserves the source file. When `pet`/coq-lsp is available in the MCP session, compile failures also include the current proof state at the error position. |
+| **`rocq_compile`** | Batch-compile Rocq source code via coqc. Best for checking a finished proof. On error, returns error positions and a `state_capture_status` field; when `pet`/coq-lsp is available and the failure is inside a proof, also returns a reusable `state_id` and the goals at the error position. For iterative development, prefer `rocq_check`. |
+| **`rocq_compile_file`** | Like `rocq_compile` but takes a file path instead of source string. More efficient for large files (avoids transmitting full source over MCP). Cleans up compilation artifacts but preserves the source file. When `pet`/coq-lsp is available and the failure is inside a proof, also returns a reusable `state_id` and the goals at the error position via `state_capture_status`. |
 | **`rocq_verify`** | Verify that a proof actually proves the original statement. Wraps in a `Module M.` sandbox to catch type redefinition, `Admitted`/`Abort`, custom axioms, and statement mismatches. Run after `rocq_compile` succeeds. |
 
 ### Interactive tools (pytanque-based, require `pet`)
@@ -61,6 +61,7 @@ The server exposes eleven MCP tools:
 | `ROCQ_COQC_TIMEOUT` | `60` | Timeout (seconds) for `rocq_compile` |
 | `ROCQ_VERIFY_TIMEOUT` | `120` | Timeout (seconds) for `rocq_verify` |
 | `ROCQ_PET_TIMEOUT` | `30` | Timeout (seconds) for pytanque-based tools |
+| `ROCQ_ENRICHMENT_TIMEOUT_CAP` | `5.0` | Cap (seconds) on per-call proof-state capture after a `rocq_compile` / `rocq_compile_file` failure |
 | `ROCQ_COQC_BINARY` | `coqc` | Path to the `coqc` binary |
 | `ROCQ_MAX_SOURCE_SIZE` | `1000000` | Maximum source size in bytes |
 

--- a/src/rocq_mcp/compile.py
+++ b/src/rocq_mcp/compile.py
@@ -401,77 +401,6 @@ def _build_compile_result(
     return result_dict
 
 
-async def _capture_compile_error_state(
-    source: str,
-    workspace: str,
-    lifespan_state: dict[str, Any],
-    *,
-    line: int,
-    character: int,
-    file_label: str,
-    resolved_file: str | None = None,
-) -> dict[str, Any] | None:
-    """Best-effort PET lookup of the proof state at a compile error."""
-    try:
-        from rocq_mcp.interactive import capture_position_state
-    except ImportError:
-        return None
-
-    lookup_file = resolved_file
-    temp_path: str | None = None
-
-    if lookup_file is None:
-        ws = Path(workspace).resolve()
-        try:
-            with tempfile.NamedTemporaryFile(
-                suffix=".v",
-                mode="w",
-                delete=False,
-                dir=str(ws),
-            ) as f:
-                f.write(source)
-                f.flush()
-                temp_path = f.name
-        except OSError:
-            return None
-        lookup_file = temp_path
-
-    try:
-        state_result = await capture_position_state(
-            file=file_label,
-            resolved_file=lookup_file,
-            workspace=workspace,
-            lifespan_state=lifespan_state,
-            line=line,
-            character=character,
-            description="Compile error state capture",
-            track_staleness=resolved_file is not None,
-        )
-    finally:
-        if temp_path is not None:
-            _server._cleanup_coqc_artifacts(temp_path)
-
-    if not isinstance(state_result, dict) or not state_result.get("success"):
-        return None
-    return state_result
-
-
-def _merge_compile_error_state(
-    result_dict: dict[str, Any],
-    state_result: dict[str, Any],
-) -> dict[str, Any]:
-    """Attach captured proof-state fields to a compile failure result."""
-    for key in ("state_id", "goals", "file", "theorem", "proof_finished"):
-        result_dict[key] = state_result[key]
-    result_dict["hint"] = (
-        "Interactive proof state captured at the error position. "
-        f"Use rocq_check(from_state={state_result['state_id']}) or "
-        f"rocq_step_multi(from_state={state_result['state_id']}) "
-        "to explore fixes."
-    )
-    return result_dict
-
-
 # ---------------------------------------------------------------------------
 # Tool: rocq_compile (core implementation)
 # ---------------------------------------------------------------------------
@@ -504,39 +433,6 @@ def run_compile(
         timeout,
         include_warnings,
     )
-
-
-async def run_compile_with_state(
-    source: str,
-    workspace: str,
-    timeout: int,
-    include_warnings: bool = True,
-    lifespan_state: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Async wrapper for run_compile that enriches failures with PET state."""
-    result = run_compile(source, workspace, timeout, include_warnings)
-    if (
-        lifespan_state is None
-        or result.get("success")
-        or "error_positions" not in result
-    ):
-        return result
-
-    primary_error = _first_error_from_positions(result["error_positions"])
-    if primary_error is None:
-        return result
-
-    state_result = await _capture_compile_error_state(
-        source,
-        workspace,
-        lifespan_state,
-        line=primary_error["line"],
-        character=primary_error["character"],
-        file_label="<proof>",
-    )
-    if state_result is None:
-        return result
-    return _merge_compile_error_state(result, state_result)
 
 
 # ---------------------------------------------------------------------------
@@ -584,46 +480,6 @@ def run_compile_file(
         file_label=file,
         clean_tmp_paths=False,
     )
-
-
-async def run_compile_file_with_state(
-    file: str,
-    workspace: str,
-    timeout: int,
-    include_warnings: bool = True,
-    lifespan_state: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Async wrapper for run_compile_file that enriches failures with PET state."""
-    try:
-        resolved_file = _server._resolve_file_in_workspace(file, workspace)
-    except (ValueError, FileNotFoundError):
-        resolved_file = None
-
-    result = run_compile_file(file, workspace, timeout, include_warnings)
-    if (
-        lifespan_state is None
-        or result.get("success")
-        or "error_positions" not in result
-        or resolved_file is None
-    ):
-        return result
-
-    primary_error = _first_error_from_positions(result["error_positions"])
-    if primary_error is None:
-        return result
-
-    state_result = await _capture_compile_error_state(
-        "",
-        workspace,
-        lifespan_state,
-        line=primary_error["line"],
-        character=primary_error["character"],
-        file_label=file,
-        resolved_file=resolved_file,
-    )
-    if state_result is None:
-        return result
-    return _merge_compile_error_state(result, state_result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/rocq_mcp/compile.py
+++ b/src/rocq_mcp/compile.py
@@ -199,6 +199,24 @@ def _parse_coqc_error_positions(stderr: str) -> list[dict[str, Any]]:
     return positions
 
 
+def _first_error_position(stderr: str) -> dict[str, Any] | None:
+    """Return the first Error-level diagnostic position, skipping warnings."""
+    for pos in _parse_coqc_error_positions(stderr):
+        if pos["message"].startswith("Error:"):
+            return pos
+    return None
+
+
+def _first_error_from_positions(
+    positions: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the first Error-level entry from parsed diagnostic positions."""
+    for pos in positions:
+        if pos["message"].startswith("Error:"):
+            return pos
+    return None
+
+
 # Regex to match coqc diagnostic blocks: File "path", line N, characters S-E:\n<body>
 _COQC_DIAG_RE = re.compile(
     r'(File "([^"]*)", line (\d+), characters (\d+)-(\d+):\s*\n)(.*?)(?=File "|$)',
@@ -391,6 +409,74 @@ def _build_compile_result(
     return result_dict
 
 
+async def _capture_compile_error_state(
+    source: str,
+    workspace: str,
+    lifespan_state: dict[str, Any],
+    *,
+    line: int,
+    character: int,
+    file_label: str,
+    resolved_file: str | None = None,
+) -> dict[str, Any] | None:
+    """Best-effort PET lookup of the proof state at a compile error."""
+    try:
+        from rocq_mcp.interactive import capture_position_state
+    except ImportError:
+        return None
+
+    ws = Path(workspace).resolve()
+    lookup_file = resolved_file
+    temp_path: str | None = None
+
+    if lookup_file is None:
+        with tempfile.NamedTemporaryFile(
+            suffix=".v",
+            mode="w",
+            delete=False,
+            dir=str(ws),
+        ) as f:
+            f.write(source)
+            f.flush()
+            temp_path = f.name
+        lookup_file = temp_path
+
+    try:
+        state_result = await capture_position_state(
+            file=file_label,
+            resolved_file=lookup_file,
+            workspace=workspace,
+            lifespan_state=lifespan_state,
+            line=line,
+            character=character,
+            description="Compile error state capture",
+            track_staleness=resolved_file is not None,
+        )
+    finally:
+        if temp_path is not None:
+            _server._cleanup_coqc_artifacts(temp_path)
+
+    if not isinstance(state_result, dict) or not state_result.get("success"):
+        return None
+    return state_result
+
+
+def _merge_compile_error_state(
+    result_dict: dict[str, Any],
+    state_result: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach captured proof-state fields to a compile failure result."""
+    for key in ("state_id", "goals", "file", "theorem", "proof_finished"):
+        result_dict[key] = state_result[key]
+    result_dict["hint"] = (
+        "Interactive proof state captured at the error position. "
+        f"Use rocq_check(from_state={state_result['state_id']}) or "
+        f"rocq_step_multi(from_state={state_result['state_id']}) "
+        "to explore fixes."
+    )
+    return result_dict
+
+
 # ---------------------------------------------------------------------------
 # Tool: rocq_compile (core implementation)
 # ---------------------------------------------------------------------------
@@ -417,7 +503,12 @@ def run_compile(
         return {"success": False, "error": forbidden}
 
     result = _run_coqc(source, workspace, timeout)
-    return _build_compile_result(result, source, timeout, include_warnings)
+    return _build_compile_result(
+        result,
+        source,
+        timeout,
+        include_warnings,
+    )
 
 
 async def run_compile_with_state(
@@ -427,13 +518,30 @@ async def run_compile_with_state(
     include_warnings: bool = True,
     lifespan_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Async wrapper for run_compile.
+    """Async wrapper for run_compile that enriches failures with PET state."""
+    result = run_compile(source, workspace, timeout, include_warnings)
+    if (
+        lifespan_state is None
+        or result.get("success")
+        or "error_positions" not in result
+    ):
+        return result
 
-    The compile MCP wrappers are async, so keep a matching async boundary here
-    even before compile errors start consulting PET state.
-    """
-    del lifespan_state
-    return run_compile(source, workspace, timeout, include_warnings)
+    primary_error = _first_error_from_positions(result["error_positions"])
+    if primary_error is None:
+        return result
+
+    state_result = await _capture_compile_error_state(
+        source,
+        workspace,
+        lifespan_state,
+        line=primary_error["line"],
+        character=primary_error["character"],
+        file_label="<proof>",
+    )
+    if state_result is None:
+        return result
+    return _merge_compile_error_state(result, state_result)
 
 
 # ---------------------------------------------------------------------------
@@ -490,9 +598,42 @@ async def run_compile_file_with_state(
     include_warnings: bool = True,
     lifespan_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Async wrapper for run_compile_file."""
-    del lifespan_state
-    return run_compile_file(file, workspace, timeout, include_warnings)
+    """Async wrapper for run_compile_file that enriches failures with PET state."""
+    try:
+        resolved_file = _server._resolve_file_in_workspace(file, workspace)
+    except (ValueError, FileNotFoundError):
+        resolved_file = None
+
+    try:
+        source = Path(resolved_file).read_text() if resolved_file else ""
+    except OSError:
+        source = ""
+
+    result = run_compile_file(file, workspace, timeout, include_warnings)
+    if (
+        lifespan_state is None
+        or result.get("success")
+        or "error_positions" not in result
+        or resolved_file is None
+    ):
+        return result
+
+    primary_error = _first_error_from_positions(result["error_positions"])
+    if primary_error is None:
+        return result
+
+    state_result = await _capture_compile_error_state(
+        source,
+        workspace,
+        lifespan_state,
+        line=primary_error["line"],
+        character=primary_error["character"],
+        file_label=file,
+        resolved_file=resolved_file,
+    )
+    if state_result is None:
+        return result
+    return _merge_compile_error_state(result, state_result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/rocq_mcp/compile.py
+++ b/src/rocq_mcp/compile.py
@@ -420,6 +420,22 @@ def run_compile(
     return _build_compile_result(result, source, timeout, include_warnings)
 
 
+async def run_compile_with_state(
+    source: str,
+    workspace: str,
+    timeout: int,
+    include_warnings: bool = True,
+    lifespan_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Async wrapper for run_compile.
+
+    The compile MCP wrappers are async, so keep a matching async boundary here
+    even before compile errors start consulting PET state.
+    """
+    del lifespan_state
+    return run_compile(source, workspace, timeout, include_warnings)
+
+
 # ---------------------------------------------------------------------------
 # Tool: rocq_compile_file (core implementation)
 # ---------------------------------------------------------------------------
@@ -465,6 +481,18 @@ def run_compile_file(
         file_label=file,
         clean_tmp_paths=False,
     )
+
+
+async def run_compile_file_with_state(
+    file: str,
+    workspace: str,
+    timeout: int,
+    include_warnings: bool = True,
+    lifespan_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Async wrapper for run_compile_file."""
+    del lifespan_state
+    return run_compile_file(file, workspace, timeout, include_warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/src/rocq_mcp/compile.py
+++ b/src/rocq_mcp/compile.py
@@ -199,14 +199,6 @@ def _parse_coqc_error_positions(stderr: str) -> list[dict[str, Any]]:
     return positions
 
 
-def _first_error_position(stderr: str) -> dict[str, Any] | None:
-    """Return the first Error-level diagnostic position, skipping warnings."""
-    for pos in _parse_coqc_error_positions(stderr):
-        if pos["message"].startswith("Error:"):
-            return pos
-    return None
-
-
 def _first_error_from_positions(
     positions: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
@@ -425,20 +417,23 @@ async def _capture_compile_error_state(
     except ImportError:
         return None
 
-    ws = Path(workspace).resolve()
     lookup_file = resolved_file
     temp_path: str | None = None
 
     if lookup_file is None:
-        with tempfile.NamedTemporaryFile(
-            suffix=".v",
-            mode="w",
-            delete=False,
-            dir=str(ws),
-        ) as f:
-            f.write(source)
-            f.flush()
-            temp_path = f.name
+        ws = Path(workspace).resolve()
+        try:
+            with tempfile.NamedTemporaryFile(
+                suffix=".v",
+                mode="w",
+                delete=False,
+                dir=str(ws),
+            ) as f:
+                f.write(source)
+                f.flush()
+                temp_path = f.name
+        except OSError:
+            return None
         lookup_file = temp_path
 
     try:
@@ -604,11 +599,6 @@ async def run_compile_file_with_state(
     except (ValueError, FileNotFoundError):
         resolved_file = None
 
-    try:
-        source = Path(resolved_file).read_text() if resolved_file else ""
-    except OSError:
-        source = ""
-
     result = run_compile_file(file, workspace, timeout, include_warnings)
     if (
         lifespan_state is None
@@ -623,7 +613,7 @@ async def run_compile_file_with_state(
         return result
 
     state_result = await _capture_compile_error_state(
-        source,
+        "",
         workspace,
         lifespan_state,
         line=primary_error["line"],

--- a/src/rocq_mcp/compile.py
+++ b/src/rocq_mcp/compile.py
@@ -47,6 +47,7 @@ import rocq_mcp.server as _server
 
 _MAX_ERROR_LENGTH: int = 4000
 _MAX_FORMAT_WARNINGS: int = 3
+_PROOF_FILE_LABEL: str = "<proof>"
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +228,7 @@ def _format_error(
     proof_str: str,
     *,
     include_warnings: bool = True,
-    file_label: str = "<proof>",
+    file_label: str = _PROOF_FILE_LABEL,
 ) -> str:
     """Reformat a raw coqc stderr string into LLM-friendly feedback.
 
@@ -339,7 +340,7 @@ def _build_compile_result(
     timeout: int,
     include_warnings: bool,
     *,
-    file_label: str = "<proof>",
+    file_label: str = _PROOF_FILE_LABEL,
     clean_tmp_paths: bool = True,
 ) -> dict[str, Any]:
     """Build a structured result dict from a coqc subprocess result.
@@ -940,7 +941,7 @@ def _run_phase1_module_m(
     if not phase1_error:
         raw = phase1_stderr.strip()
         phase1_error = _TMP_PATH_RE.sub(
-            '"<proof>"',
+            f'"{_PROOF_FILE_LABEL}"',
             raw[-_MAX_ERROR_LENGTH:] if len(raw) > _MAX_ERROR_LENGTH else raw,
         ).strip()
         if not phase1_error:

--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -717,6 +717,85 @@ async def run_notations(
 _MAX_STEP_MULTI_TACTICS = 20
 
 
+def _build_position_start_result(
+    pet: Any,
+    *,
+    file: str,
+    resolved_file: str,
+    workspace: str,
+    lifespan_state: dict[str, Any],
+    line: int,
+    character: int,
+    track_staleness: bool = True,
+) -> dict[str, Any]:
+    """Return the rocq_start-style payload for a position-based state."""
+    _server._set_workspace_if_needed(pet, workspace, lifespan_state)
+    state = pet.get_state_at_pos(resolved_file, line, character)
+
+    file_mtime: float | None = None
+    tracked_file: str | None = None
+    if track_staleness:
+        try:
+            file_mtime = os.path.getmtime(resolved_file)
+        except OSError:
+            file_mtime = None
+        tracked_file = resolved_file
+
+    theorem = f"@pos({line},{character})"
+    state_id = _state_add(
+        state=state,
+        file=file,
+        theorem=theorem,
+        workspace=workspace,
+        parent_id=None,
+        tactic=None,
+        step=0,
+        file_mtime=file_mtime,
+        resolved_file=tracked_file,
+    )
+    goals = _try_get_goals(pet, state) or ""
+    return {
+        "success": True,
+        "state_id": state_id,
+        "goals": goals,
+        "file": file,
+        "theorem": theorem,
+        "proof_finished": getattr(state, "proof_finished", False),
+    }
+
+
+async def capture_position_state(
+    *,
+    file: str,
+    resolved_file: str,
+    workspace: str,
+    lifespan_state: dict[str, Any],
+    line: int,
+    character: int,
+    description: str,
+    track_staleness: bool = True,
+) -> dict[str, Any]:
+    """Capture a position-based proof state via the async PET helper."""
+
+    def _execute(pet: Any) -> dict[str, Any]:
+        return _build_position_start_result(
+            pet,
+            file=file,
+            resolved_file=resolved_file,
+            workspace=workspace,
+            lifespan_state=lifespan_state,
+            line=line,
+            character=character,
+            track_staleness=track_staleness,
+        )
+
+    return await _server._run_with_pet(
+        _execute,
+        lifespan_state,
+        description,
+    )
+
+
 async def run_start(
     file: str,
     theorem: str,
@@ -806,33 +885,15 @@ async def run_start(
                 "proof_finished": getattr(state, "proof_finished", False),
             }
         elif _start_by_pos:
-            _server._set_workspace_if_needed(pet, workspace, lifespan_state)
-            state = pet.get_state_at_pos(resolved_file, line, character)
-            # Capture mtime after get_state_at_pos to avoid TOCTOU gap
-            try:
-                file_mtime = os.path.getmtime(resolved_file)
-            except OSError:
-                file_mtime = None
-            state_id = _state_add(
-                state=state,
+            return _build_position_start_result(
+                pet,
                 file=file,
-                theorem=f"@pos({line},{character})",
-                workspace=workspace,
-                parent_id=None,
-                tactic=None,
-                step=0,
-                file_mtime=file_mtime,
                 resolved_file=resolved_file,
+                workspace=workspace,
+                lifespan_state=lifespan_state,
+                line=line,
+                character=character,
             )
-            goals = _try_get_goals(pet, state) or ""
-            return {
-                "success": True,
-                "state_id": state_id,
-                "goals": goals,
-                "file": file,
-                "theorem": f"@pos({line},{character})",
-                "proof_finished": getattr(state, "proof_finished", False),
-            }
         else:
             # Preamble mode
             preamble_cmds = _split_rocq_sentences(preamble) if preamble.strip() else []

--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -329,6 +329,14 @@ def _state_get(state_id: int) -> _StateEntry | None:
     return _state_table.get(state_id)
 
 
+def _state_remove(state_id: int) -> None:
+    """Drop a state from the table; clear ``_state_current_id`` if it pointed here."""
+    global _state_current_id
+    _state_table.pop(state_id, None)
+    if _state_current_id == state_id:
+        _state_current_id = None
+
+
 def _state_get_or_error(state_id: int) -> tuple[_StateEntry | None, str | None]:
     """Look up a state by ID, returning (entry, None) or (None, error_msg)."""
     entry = _state_table.get(state_id)
@@ -774,8 +782,13 @@ async def capture_position_state(
     character: int,
     description: str,
     track_staleness: bool = True,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
-    """Capture a position-based proof state via the async PET helper."""
+    """Capture a position-based proof state via the async PET helper.
+
+    ``timeout`` (seconds) is forwarded to ``_run_with_pet``; when ``None``
+    the lifespan default is used.
+    """
 
     def _execute(pet: Any) -> dict[str, Any]:
         return _build_position_start_result(
@@ -793,6 +806,7 @@ async def capture_position_state(
         _execute,
         lifespan_state,
         description,
+        timeout=timeout,
     )
 
 

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -731,8 +731,10 @@ async def rocq_compile(
     rocq_check (faster, cached imports, returns state for recovery)
     or rocq_step_multi (try multiple tactics at once).
 
-    On error, returns error_positions for jumping to the failure via
-    rocq_start(file=..., line=..., character=...).
+    On structured errors, returns error_positions for jumping to the
+    failure via rocq_start(file=..., line=..., character=...). When
+    coq-lsp is available in the active MCP session, also captures the
+    current proof state at the error position automatically.
 
     Args:
         source: Complete Rocq (.v) file content to compile.
@@ -777,8 +779,10 @@ async def rocq_compile_file(
     More efficient for large files (avoids transmitting full source).
     The file must already exist within the workspace.
 
-    On error, returns error_positions for jumping to the failure via
-    rocq_start(file=..., line=..., character=...).
+    On structured errors, returns error_positions for jumping to the
+    failure via rocq_start(file=..., line=..., character=...). When
+    coq-lsp is available in the active MCP session, also captures the
+    current proof state at the error position automatically.
 
     Args:
         file: Path to the .v file (relative to workspace).

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import signal
 import subprocess
+import tempfile
 import threading
 from pathlib import Path
 from typing import Any, Callable
@@ -695,13 +696,13 @@ async def _run_with_pet(
 # defined, because compile and interactive import from this module.
 
 from rocq_mcp.compile import (  # noqa: E402
+    _first_error_from_positions,
     run_compile,
     run_compile_file,
-    run_compile_with_state,
-    run_compile_file_with_state,
     run_verify,
 )
 from rocq_mcp.interactive import (  # noqa: E402
+    capture_position_state,
     run_assumptions,
     run_query,
     run_start,
@@ -710,6 +711,154 @@ from rocq_mcp.interactive import (  # noqa: E402
     run_toc,
     run_notations,
 )
+
+# ---------------------------------------------------------------------------
+# Compile-error-state orchestration
+# ---------------------------------------------------------------------------
+# These helpers wrap the coqc-only run_compile / run_compile_file with
+# best-effort PET state capture at the error position.  They live here
+# (not in compile.py) so compile.py stays free of any pytanque dependency
+# for its core operation.
+
+
+async def _capture_compile_error_state(
+    source: str,
+    workspace: str,
+    lifespan_state: dict[str, Any],
+    *,
+    line: int,
+    character: int,
+    file_label: str,
+    resolved_file: str | None = None,
+) -> dict[str, Any] | None:
+    """Best-effort PET lookup of the proof state at a compile error."""
+    lookup_file = resolved_file
+    temp_path: str | None = None
+
+    if lookup_file is None:
+        ws = Path(workspace).resolve()
+        try:
+            with tempfile.NamedTemporaryFile(
+                suffix=".v",
+                mode="w",
+                delete=False,
+                dir=str(ws),
+            ) as f:
+                f.write(source)
+                f.flush()
+                temp_path = f.name
+        except OSError:
+            return None
+        lookup_file = temp_path
+
+    try:
+        state_result = await capture_position_state(
+            file=file_label,
+            resolved_file=lookup_file,
+            workspace=workspace,
+            lifespan_state=lifespan_state,
+            line=line,
+            character=character,
+            description="Compile error state capture",
+            track_staleness=resolved_file is not None,
+        )
+    finally:
+        if temp_path is not None:
+            _cleanup_coqc_artifacts(temp_path)
+
+    if not isinstance(state_result, dict) or not state_result.get("success"):
+        return None
+    return state_result
+
+
+def _merge_compile_error_state(
+    result_dict: dict[str, Any],
+    state_result: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach captured proof-state fields to a compile failure result."""
+    for key in ("state_id", "goals", "file", "theorem", "proof_finished"):
+        result_dict[key] = state_result[key]
+    result_dict["hint"] = (
+        "Interactive proof state captured at the error position. "
+        f"Use rocq_check(from_state={state_result['state_id']}) or "
+        f"rocq_step_multi(from_state={state_result['state_id']}) "
+        "to explore fixes."
+    )
+    return result_dict
+
+
+async def run_compile_with_state(
+    source: str,
+    workspace: str,
+    timeout: int,
+    include_warnings: bool = True,
+    lifespan_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Async wrapper for run_compile that enriches failures with PET state."""
+    result = run_compile(source, workspace, timeout, include_warnings)
+    if (
+        lifespan_state is None
+        or result.get("success")
+        or "error_positions" not in result
+    ):
+        return result
+
+    primary_error = _first_error_from_positions(result["error_positions"])
+    if primary_error is None:
+        return result
+
+    state_result = await _capture_compile_error_state(
+        source,
+        workspace,
+        lifespan_state,
+        line=primary_error["line"],
+        character=primary_error["character"],
+        file_label="<proof>",
+    )
+    if state_result is None:
+        return result
+    return _merge_compile_error_state(result, state_result)
+
+
+async def run_compile_file_with_state(
+    file: str,
+    workspace: str,
+    timeout: int,
+    include_warnings: bool = True,
+    lifespan_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Async wrapper for run_compile_file that enriches failures with PET state."""
+    try:
+        resolved_file = _resolve_file_in_workspace(file, workspace)
+    except (ValueError, FileNotFoundError):
+        resolved_file = None
+
+    result = run_compile_file(file, workspace, timeout, include_warnings)
+    if (
+        lifespan_state is None
+        or result.get("success")
+        or "error_positions" not in result
+        or resolved_file is None
+    ):
+        return result
+
+    primary_error = _first_error_from_positions(result["error_positions"])
+    if primary_error is None:
+        return result
+
+    state_result = await _capture_compile_error_state(
+        "",
+        workspace,
+        lifespan_state,
+        line=primary_error["line"],
+        character=primary_error["character"],
+        file_label=file,
+        resolved_file=resolved_file,
+    )
+    if state_result is None:
+        return result
+    return _merge_compile_error_state(result, state_result)
+
 
 # ---------------------------------------------------------------------------
 # Tool: rocq_compile

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -694,7 +694,13 @@ async def _run_with_pet(
 # NOTE: These imports MUST come after all shared infrastructure above is
 # defined, because compile and interactive import from this module.
 
-from rocq_mcp.compile import run_compile, run_compile_file, run_verify  # noqa: E402
+from rocq_mcp.compile import (  # noqa: E402
+    run_compile,
+    run_compile_file,
+    run_compile_with_state,
+    run_compile_file_with_state,
+    run_verify,
+)
 from rocq_mcp.interactive import (  # noqa: E402
     run_assumptions,
     run_query,
@@ -711,11 +717,12 @@ from rocq_mcp.interactive import (  # noqa: E402
 
 
 @mcp.tool
-def rocq_compile(
+async def rocq_compile(
     source: str,
     workspace: str = "",
     timeout: int = 0,
     include_warnings: bool = True,
+    ctx: Context = None,
 ) -> dict[str, Any]:
     """Compile Rocq source code and return structured errors.
 
@@ -742,7 +749,13 @@ def rocq_compile(
     if err:
         return {"success": False, "error": err}
 
-    return run_compile(source, workspace, timeout, include_warnings)
+    return await run_compile_with_state(
+        source=source,
+        workspace=workspace,
+        timeout=timeout,
+        include_warnings=include_warnings,
+        lifespan_state=ctx.lifespan_context if ctx else None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -751,11 +764,12 @@ def rocq_compile(
 
 
 @mcp.tool
-def rocq_compile_file(
+async def rocq_compile_file(
     file: str,
     workspace: str = "",
     timeout: int = 0,
     include_warnings: bool = True,
+    ctx: Context = None,
 ) -> dict[str, Any]:
     """Compile a Rocq (.v) file on disk and return structured errors.
 
@@ -781,7 +795,13 @@ def rocq_compile_file(
     if err:
         return {"success": False, "error": err}
 
-    return run_compile_file(file, workspace, timeout, include_warnings)
+    return await run_compile_file_with_state(
+        file=file,
+        workspace=workspace,
+        timeout=timeout,
+        include_warnings=include_warnings,
+        lifespan_state=ctx.lifespan_context if ctx else None,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -747,9 +747,11 @@ _ENRICHMENT_TIMEOUT_CAP: float = float(
 
 # Status enum for proof-state capture on compile errors.  Used as the
 # value type of the ``state_capture_status`` key returned by the
-# ``run_compile_*_with_state`` orchestrators.  The same set of strings is
-# also produced inside ``_run_with_pet`` under the dict key ``"reason"``
-# (see _CaptureResult below and the comment on _run_with_pet's return shape).
+# ``run_compile_*_with_state`` orchestrators.  A subset
+# (``"timeout"``, ``"crashed"``, ``"lock_contended"``, ``"unavailable"``)
+# is also produced inside ``_run_with_pet`` under the dict key
+# ``"reason"``; the remaining values (``"ok"``, ``"outside_proof"``,
+# ``"no_position"``) are derived in the orchestrator.
 _StateCaptureStatus = Literal[
     "ok",
     "outside_proof",
@@ -1000,10 +1002,21 @@ async def rocq_compile(
     rocq_check (faster, cached imports, returns state for recovery)
     or rocq_step_multi (try multiple tactics at once).
 
-    On structured errors, returns error_positions for jumping to the
-    failure via rocq_start(file=..., line=..., character=...). When
-    coq-lsp is available in the active MCP session, also captures the
-    current proof state at the error position automatically.
+    On failure, the result includes ``error_positions`` and a ``hint``.
+    When coq-lsp is available in the active MCP session, the result
+    also includes ``state_capture_status``:
+
+      - ``"ok"``: proof state was captured at the error position; the
+        result also includes ``state_id``, ``goals``, ``file``,
+        ``theorem``, and ``proof_finished``.  Recover via
+        ``rocq_check(from_state=state_id)`` or
+        ``rocq_step_multi(from_state=state_id)``.
+      - ``"outside_proof"``: error is outside any open proof; no
+        ``state_id`` is returned.  Follow the original ``hint``.
+      - ``"timeout"`` / ``"crashed"`` / ``"lock_contended"`` /
+        ``"unavailable"`` / ``"no_position"``: enrichment did not
+        succeed; follow the original ``hint`` (typically
+        ``rocq_start(file=..., line=..., character=...)``).
 
     Args:
         source: Complete Rocq (.v) file content to compile.
@@ -1048,10 +1061,21 @@ async def rocq_compile_file(
     More efficient for large files (avoids transmitting full source).
     The file must already exist within the workspace.
 
-    On structured errors, returns error_positions for jumping to the
-    failure via rocq_start(file=..., line=..., character=...). When
-    coq-lsp is available in the active MCP session, also captures the
-    current proof state at the error position automatically.
+    On failure, the result includes ``error_positions`` and a ``hint``.
+    When coq-lsp is available in the active MCP session, the result
+    also includes ``state_capture_status``:
+
+      - ``"ok"``: proof state was captured at the error position; the
+        result also includes ``state_id``, ``goals``, ``file``,
+        ``theorem``, and ``proof_finished``.  Recover via
+        ``rocq_check(from_state=state_id)`` or
+        ``rocq_step_multi(from_state=state_id)``.
+      - ``"outside_proof"``: error is outside any open proof; no
+        ``state_id`` is returned.  Follow the original ``hint``.
+      - ``"timeout"`` / ``"crashed"`` / ``"lock_contended"`` /
+        ``"unavailable"`` / ``"no_position"``: enrichment did not
+        succeed; follow the original ``hint`` (typically
+        ``rocq_start(file=..., line=..., character=...)``).
 
     Args:
         file: Path to the .v file (relative to workspace).

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -16,7 +16,7 @@ import subprocess
 import tempfile
 import threading
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal, TypedDict, get_args
 
 from fastmcp import FastMCP, Context
 from fastmcp.server.lifespan import lifespan
@@ -596,6 +596,13 @@ async def _run_with_pet(
     If *partial_state* is given (a mutable dict), *fn* can populate it
     with intermediate results.  On timeout or error the dict contents
     are merged into the error response so partial work is not lost.
+
+    The return type is left as ``Any`` because the dict shape varies by
+    failure mode (success path, ``pet_restarted``-tagged crashes,
+    ``partial_state`` merges, etc.) and a TypedDict would be unwieldy.
+    The ``"reason"`` key, when present on a failure, is a
+    :data:`_StateCaptureStatus` (one of ``"timeout"``, ``"crashed"``,
+    ``"lock_contended"``, ``"unavailable"``).
     """
     try:
         from pytanque import PetanqueError
@@ -606,6 +613,7 @@ async def _run_with_pet(
                 "pytanque is not installed. "
                 "Install with: pip install 'rocq-mcp[interactive]'"
             ),
+            "reason": "unavailable",
         }
 
     _timeout: float = timeout if timeout is not None else lifespan_state["pet_timeout"]
@@ -642,6 +650,7 @@ async def _run_with_pet(
                 "success": False,
                 "error": f"{description} timed out after {_timeout}s.",
                 "pet_restarted": True,
+                "reason": "timeout",
             }
             if partial_state:
                 _merge_partial_state(resp, partial_state)
@@ -650,6 +659,7 @@ async def _run_with_pet(
             return {
                 "success": False,
                 "error": (f"{description}: pet is busy (lock contention). Try again."),
+                "reason": "lock_contended",
             }
         except PetanqueError as e:
             if not _pet_alive(lifespan_state.get("pet_client")):
@@ -659,11 +669,12 @@ async def _run_with_pet(
                     "success": False,
                     "error": f"Pet process died: {e.message}",
                     "pet_restarted": True,
+                    "reason": "crashed",
                 }
                 if partial_state:
                     _merge_partial_state(resp, partial_state)
                 return resp
-            return {"success": False, "error": e.message}
+            return {"success": False, "error": e.message, "reason": "crashed"}
         except (BrokenPipeError, ConnectionError) as e:
             _invalidate_pet(lifespan_state)
             await _force_release_pet_lock()
@@ -673,6 +684,7 @@ async def _run_with_pet(
                 "success": False,
                 "error": f"Pet process died: {e}",
                 "pet_restarted": True,
+                "reason": "crashed",
             }
             if partial_state:
                 _merge_partial_state(resp, partial_state)
@@ -681,9 +693,14 @@ async def _run_with_pet(
             return {
                 "success": False,
                 "error": "pet binary not found on PATH. Install coq-lsp.",
+                "reason": "unavailable",
             }
         except (OSError, RuntimeError, ValueError, TypeError) as e:
-            resp = {"success": False, "error": f"Unexpected error: {e}"}
+            resp = {
+                "success": False,
+                "error": f"Unexpected error: {e}",
+                "reason": "crashed",
+            }
             if partial_state:
                 _merge_partial_state(resp, partial_state)
             return resp
@@ -696,13 +713,14 @@ async def _run_with_pet(
 # defined, because compile and interactive import from this module.
 
 from rocq_mcp.compile import (  # noqa: E402
+    _PROOF_FILE_LABEL,
     _first_error_from_positions,
     run_compile,
     run_compile_file,
     run_verify,
 )
 from rocq_mcp.interactive import (  # noqa: E402
-    capture_position_state,
+    _state_remove,
     run_assumptions,
     run_query,
     run_start,
@@ -720,6 +738,37 @@ from rocq_mcp.interactive import (  # noqa: E402
 # (not in compile.py) so compile.py stays free of any pytanque dependency
 # for its core operation.
 
+# Cap on how long enrichment may spend per call.  Coqc has already returned
+# the basic error by the time we reach this code, so a stuck pet must not
+# silently steal more than this from the agent.
+_ENRICHMENT_TIMEOUT_CAP: float = float(
+    os.environ.get("ROCQ_ENRICHMENT_TIMEOUT_CAP", "5.0")
+)
+
+# Status enum for proof-state capture on compile errors.  Used as the
+# value type of the ``state_capture_status`` key returned by the
+# ``run_compile_*_with_state`` orchestrators.  The same set of strings is
+# also produced inside ``_run_with_pet`` under the dict key ``"reason"``
+# (see _CaptureResult below and the comment on _run_with_pet's return shape).
+_StateCaptureStatus = Literal[
+    "ok",
+    "outside_proof",
+    "timeout",
+    "crashed",
+    "unavailable",
+    "lock_contended",
+    "no_position",
+]
+
+_VALID_STATE_CAPTURE_STATUSES: frozenset[str] = frozenset(get_args(_StateCaptureStatus))
+
+
+class _CaptureResult(TypedDict):
+    """Return shape of :func:`_capture_compile_error_state`."""
+
+    status: _StateCaptureStatus
+    state: dict[str, Any] | None
+
 
 async def _capture_compile_error_state(
     source: str,
@@ -730,8 +779,23 @@ async def _capture_compile_error_state(
     character: int,
     file_label: str,
     resolved_file: str | None = None,
-) -> dict[str, Any] | None:
-    """Best-effort PET lookup of the proof state at a compile error."""
+    timeout: float | None = None,
+) -> _CaptureResult:
+    """Best-effort PET lookup of the proof state at a compile error.
+
+    Returns a :class:`_CaptureResult` ``{"status": <_StateCaptureStatus>,
+    "state": <dict|None>}``.  ``state`` is the captured state dict on
+    ``"ok"`` / ``"outside_proof"``, ``None`` otherwise.
+    """
+    # Lazy import: defensive against a future split where rocq_mcp.interactive
+    # becomes optional. In current packaging this branch is unreachable; the
+    # realistic "unavailable" case fires from _run_with_pet via
+    # reason="unavailable".
+    try:
+        from rocq_mcp.interactive import capture_position_state as _cps
+    except ImportError:
+        return {"status": "unavailable", "state": None}
+
     lookup_file = resolved_file
     temp_path: str | None = None
 
@@ -748,34 +812,62 @@ async def _capture_compile_error_state(
                 f.flush()
                 temp_path = f.name
         except OSError:
-            return None
+            # Workspace I/O failure (no pet involvement). We collapse this
+            # into "crashed" -- our catch-all for "enrichment couldn't run"
+            # -- since we don't currently distinguish pre-pet failures from
+            # real pet crashes.
+            return {"status": "crashed", "state": None}
         lookup_file = temp_path
 
     try:
-        state_result = await capture_position_state(
-            file=file_label,
-            resolved_file=lookup_file,
-            workspace=workspace,
-            lifespan_state=lifespan_state,
-            line=line,
-            character=character,
-            description="Compile error state capture",
-            track_staleness=resolved_file is not None,
-        )
+        try:
+            state_result = await _cps(
+                file=file_label,
+                resolved_file=lookup_file,
+                workspace=workspace,
+                lifespan_state=lifespan_state,
+                line=line,
+                character=character,
+                description="Compile error state capture",
+                track_staleness=resolved_file is not None,
+                timeout=timeout,
+            )
+        except Exception:
+            # PetanqueError (or any other exception) escaping capture_position_state
+            # is treated as a crash so the caller can surface ``state_capture_status``.
+            return {"status": "crashed", "state": None}
     finally:
         if temp_path is not None:
             _cleanup_coqc_artifacts(temp_path)
 
-    if not isinstance(state_result, dict) or not state_result.get("success"):
-        return None
-    return state_result
+    if not isinstance(state_result, dict):
+        return {"status": "crashed", "state": None}
+
+    if not state_result.get("success"):
+        reason = state_result.get("reason", "crashed")
+        if reason not in _VALID_STATE_CAPTURE_STATUSES:
+            reason = "crashed"
+        return {"status": reason, "state": None}
+
+    goals = state_result.get("goals", "")
+    proof_finished = state_result.get("proof_finished", False)
+    if not goals or proof_finished:
+        _state_remove(state_result["state_id"])
+        return {"status": "outside_proof", "state": None}
+    return {"status": "ok", "state": state_result}
 
 
 def _merge_compile_error_state(
     result_dict: dict[str, Any],
     state_result: dict[str, Any],
 ) -> dict[str, Any]:
-    """Attach captured proof-state fields to a compile failure result."""
+    """Attach captured proof-state fields to a compile failure result.
+
+    Only called when ``state_capture_status == "ok"``: the captured state
+    is actionable (``goals`` non-empty AND not ``proof_finished``), so we
+    always merge the state fields and rewrite the hint to point at
+    ``rocq_check(from_state=...)``.
+    """
     for key in ("state_id", "goals", "file", "theorem", "proof_finished"):
         result_dict[key] = state_result[key]
     result_dict["hint"] = (
@@ -787,6 +879,58 @@ def _merge_compile_error_state(
     return result_dict
 
 
+def _enrichment_timeout(lifespan_state: dict[str, Any]) -> float:
+    """Per-call enrichment timeout, capped by ``_ENRICHMENT_TIMEOUT_CAP``."""
+    pet_timeout = lifespan_state.get("pet_timeout", ROCQ_PET_TIMEOUT)
+    return min(float(pet_timeout), _ENRICHMENT_TIMEOUT_CAP)
+
+
+async def _enrich_compile_failure(
+    result: dict[str, Any],
+    *,
+    source: str,
+    workspace: str,
+    lifespan_state: dict[str, Any],
+    file_label: str,
+    resolved_file: str | None = None,
+) -> dict[str, Any]:
+    """Apply state-capture enrichment to a failed compile result.
+
+    Mutates *result* in place and returns it.  Sets ``state_capture_status``
+    (a :data:`_StateCaptureStatus`) on every path: ``"no_position"`` when
+    there is no usable error position, otherwise the status returned by
+    :func:`_capture_compile_error_state`.
+
+    The caller is responsible for the mode-specific short-circuits
+    (``lifespan_state is None``, ``result.get("success")``, and missing
+    ``resolved_file`` in file-path mode).
+    """
+    if "error_positions" not in result:
+        result["state_capture_status"] = "no_position"
+        return result
+
+    primary_error = _first_error_from_positions(result["error_positions"])
+    if primary_error is None:
+        result["state_capture_status"] = "no_position"
+        return result
+
+    capture = await _capture_compile_error_state(
+        source,
+        workspace,
+        lifespan_state,
+        line=primary_error["line"],
+        character=primary_error["character"],
+        file_label=file_label,
+        resolved_file=resolved_file,
+        timeout=_enrichment_timeout(lifespan_state),
+    )
+    result["state_capture_status"] = capture["status"]
+    state_result = capture["state"]
+    if state_result is None or capture["status"] != "ok":
+        return result
+    return _merge_compile_error_state(result, state_result)
+
+
 async def run_compile_with_state(
     source: str,
     workspace: str,
@@ -796,28 +940,15 @@ async def run_compile_with_state(
 ) -> dict[str, Any]:
     """Async wrapper for run_compile that enriches failures with PET state."""
     result = run_compile(source, workspace, timeout, include_warnings)
-    if (
-        lifespan_state is None
-        or result.get("success")
-        or "error_positions" not in result
-    ):
+    if lifespan_state is None or result.get("success"):
         return result
-
-    primary_error = _first_error_from_positions(result["error_positions"])
-    if primary_error is None:
-        return result
-
-    state_result = await _capture_compile_error_state(
-        source,
-        workspace,
-        lifespan_state,
-        line=primary_error["line"],
-        character=primary_error["character"],
-        file_label="<proof>",
+    return await _enrich_compile_failure(
+        result,
+        source=source,
+        workspace=workspace,
+        lifespan_state=lifespan_state,
+        file_label=_PROOF_FILE_LABEL,
     )
-    if state_result is None:
-        return result
-    return _merge_compile_error_state(result, state_result)
 
 
 async def run_compile_file_with_state(
@@ -834,30 +965,19 @@ async def run_compile_file_with_state(
         resolved_file = None
 
     result = run_compile_file(file, workspace, timeout, include_warnings)
-    if (
-        lifespan_state is None
-        or result.get("success")
-        or "error_positions" not in result
-        or resolved_file is None
-    ):
+    if lifespan_state is None or result.get("success"):
         return result
-
-    primary_error = _first_error_from_positions(result["error_positions"])
-    if primary_error is None:
+    if resolved_file is None:
+        result["state_capture_status"] = "no_position"
         return result
-
-    state_result = await _capture_compile_error_state(
-        "",
-        workspace,
-        lifespan_state,
-        line=primary_error["line"],
-        character=primary_error["character"],
+    return await _enrich_compile_failure(
+        result,
+        source="",
+        workspace=workspace,
+        lifespan_state=lifespan_state,
         file_label=file,
         resolved_file=resolved_file,
     )
-    if state_result is None:
-        return result
-    return _merge_compile_error_state(result, state_result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,51 @@ PET_AVAILABLE: bool = shutil.which("pet") is not None
 
 
 # ---------------------------------------------------------------------------
+# Shared test helpers (used across compile / compile_file / integration suites)
+# ---------------------------------------------------------------------------
+
+# Canonical "Real failure" stderr fixture used by status-derivation tests.
+_DEFAULT_STDERR = (
+    'File "/tmp/tmp.v", line 2, characters 0-5:\n' "Error: Real failure.\n"
+)
+
+
+def _fake_coqc_result(stderr, returncode=1):
+    """Build a fake ``_run_coqc`` / ``_run_coqc_file`` return dict."""
+    return {
+        "returncode": returncode,
+        "stdout": "",
+        "stderr": stderr,
+        "timed_out": False,
+    }
+
+
+def _patch_compile_error(monkeypatch, stderr):
+    """Force ``_run_coqc`` to produce a failing fake result with *stderr*."""
+    from rocq_mcp import compile as _compile
+
+    monkeypatch.setattr(
+        _compile,
+        "_run_coqc",
+        lambda *a, **kw: _fake_coqc_result(stderr),
+    )
+
+
+def _patch_capture_position_state(monkeypatch, async_fn):
+    """Replace the lazy-imported ``capture_position_state`` symbol."""
+    from rocq_mcp import interactive as _interactive
+
+    monkeypatch.setattr(_interactive, "capture_position_state", async_fn)
+
+
+class _MockContext:
+    """Minimal mock for FastMCP Context to inject lifespan_state."""
+
+    def __init__(self, lifespan_state):
+        self.lifespan_context = lifespan_state
+
+
+# ---------------------------------------------------------------------------
 # Workspace fixture
 # ---------------------------------------------------------------------------
 

--- a/tests/test_assumptions.py
+++ b/tests/test_assumptions.py
@@ -371,10 +371,9 @@ class TestRocqAssumptionsWrapper:
     @pytest.mark.asyncio
     async def test_invalid_workspace_returns_error(self):
         from rocq_mcp.server import rocq_assumptions
-        from unittest.mock import MagicMock
+        from tests.conftest import _MockContext
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {}
+        mock_ctx = _MockContext({})
         result = await rocq_assumptions(
             name="foo",
             file="test.v",
@@ -387,7 +386,7 @@ class TestRocqAssumptionsWrapper:
     async def test_params_forwarded(self, monkeypatch, tmp_path):
         """Wrapper should forward all params to run_assumptions."""
         from rocq_mcp.server import rocq_assumptions
-        from unittest.mock import MagicMock
+        from tests.conftest import _MockContext
         import rocq_mcp.server as _server
 
         captured = {}
@@ -399,8 +398,7 @@ class TestRocqAssumptionsWrapper:
         monkeypatch.setattr(_server, "run_assumptions", mock_run_assumptions)
         monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"pet_client": None}
+        mock_ctx = _MockContext({"pet_client": None})
 
         await rocq_assumptions(
             name="my_thm",

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -10,7 +10,9 @@ Tests are grouped into:
 
 from __future__ import annotations
 
+import asyncio
 import glob as glob_mod
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,6 +20,11 @@ from tests.conftest import COQC_AVAILABLE
 from rocq_mcp.server import rocq_compile
 
 pytestmark = pytest.mark.skipif(not COQC_AVAILABLE, reason="coqc not available")
+
+
+def _call_rocq_compile(**kwargs):
+    """Run the async server wrapper from synchronous tests."""
+    return asyncio.run(rocq_compile(**kwargs))
 
 
 # ---------------------------------------------------------------------------
@@ -29,22 +36,24 @@ class TestCompileSuccess:
     """Sources that compile without error."""
 
     def test_simple_proof(self, workspace, simple_proof):
-        result = rocq_compile(source=simple_proof, workspace=str(workspace))
+        result = _call_rocq_compile(source=simple_proof, workspace=str(workspace))
         assert result["success"] is True
 
     def test_empty_source(self, workspace):
         """An empty file is valid Rocq source."""
-        result = rocq_compile(source="", workspace=str(workspace))
+        result = _call_rocq_compile(source="", workspace=str(workspace))
         assert result["success"] is True
 
     def test_braces_in_proof(self, workspace, braces_proof):
         """Proofs using { } subgoal braces must not confuse f-string templates."""
-        result = rocq_compile(source=braces_proof, workspace=str(workspace))
+        result = _call_rocq_compile(source=braces_proof, workspace=str(workspace))
         assert result["success"] is True
 
     def test_multiline_import(self, workspace, multiline_import_proof):
         """Multi-line From ... Require Import must compile correctly."""
-        result = rocq_compile(source=multiline_import_proof, workspace=str(workspace))
+        result = _call_rocq_compile(
+            source=multiline_import_proof, workspace=str(workspace)
+        )
         assert result["success"] is True
 
 
@@ -59,7 +68,7 @@ class TestCompileErrors:
     def test_type_error(self, workspace):
         """A proof of an obviously false statement must fail."""
         source = "Theorem bad : nat = bool.\n" "Proof. reflexivity. Qed.\n"
-        result = rocq_compile(source=source, workspace=str(workspace))
+        result = _call_rocq_compile(source=source, workspace=str(workspace))
         assert result["success"] is False
         assert "error" in result
         assert len(result["error"]) > 0
@@ -67,14 +76,14 @@ class TestCompileErrors:
     def test_syntax_error(self, workspace):
         """Malformed syntax should produce a compilation error."""
         source = "Theorem bad : .\nQed.\n"
-        result = rocq_compile(source=source, workspace=str(workspace))
+        result = _call_rocq_compile(source=source, workspace=str(workspace))
         assert result["success"] is False
         assert "error" in result
 
     def test_missing_import(self, workspace):
         """Using R without importing Reals should fail."""
         source = "Theorem test : forall x : R, x = x.\n" "Proof. reflexivity. Qed.\n"
-        result = rocq_compile(source=source, workspace=str(workspace))
+        result = _call_rocq_compile(source=source, workspace=str(workspace))
         assert result["success"] is False
         assert "error" in result
 
@@ -88,7 +97,9 @@ class TestCompileTimeout:
     """Diverging tactics should trigger timeout."""
 
     def test_diverging_tactic(self, workspace, timeout_proof):
-        result = rocq_compile(source=timeout_proof, workspace=str(workspace), timeout=3)
+        result = _call_rocq_compile(
+            source=timeout_proof, workspace=str(workspace), timeout=3
+        )
         assert result["success"] is False
         assert "timed out" in result["error"].lower()
 
@@ -103,7 +114,7 @@ class TestCompileInputValidation:
 
     def test_bad_workspace(self):
         """Non-existent workspace should return a clear error."""
-        result = rocq_compile(source="", workspace="/nonexistent/path/xyz")
+        result = _call_rocq_compile(source="", workspace="/nonexistent/path/xyz")
         assert result["success"] is False
         assert (
             "not exist" in result["error"].lower()
@@ -113,7 +124,9 @@ class TestCompileInputValidation:
 
     def test_oversized_source(self, workspace):
         """Source exceeding ROCQ_MAX_SOURCE_SIZE should be rejected early."""
-        result = rocq_compile(source="x" * 2_000_000, workspace=str(workspace))
+        result = _call_rocq_compile(
+            source="x" * 2_000_000, workspace=str(workspace)
+        )
         assert result["success"] is False
         assert "size" in result["error"].lower()
 
@@ -122,7 +135,7 @@ class TestCompileInputValidation:
         monkeypatch.setattr(
             "rocq_mcp.server.ROCQ_COQC_BINARY", "nonexistent_coqc_binary_xyz"
         )
-        result = rocq_compile(source="", workspace=str(workspace))
+        result = _call_rocq_compile(source="", workspace=str(workspace))
         assert result["success"] is False
         assert "not found" in result["error"].lower()
 
@@ -137,7 +150,7 @@ class TestCompileCleanup:
 
     def test_no_artifacts_left(self, workspace, simple_proof):
         before = set(glob_mod.glob(str(workspace / "*")))
-        rocq_compile(source=simple_proof, workspace=str(workspace))
+        _call_rocq_compile(source=simple_proof, workspace=str(workspace))
         after = set(glob_mod.glob(str(workspace / "*")))
         assert before == after, f"Leftover artifacts: {after - before}"
 
@@ -145,14 +158,14 @@ class TestCompileCleanup:
         """Even on compilation error, temp files should be cleaned up."""
         source = "Theorem bad : .\nQed.\n"
         before = set(glob_mod.glob(str(workspace / "*")))
-        rocq_compile(source=source, workspace=str(workspace))
+        _call_rocq_compile(source=source, workspace=str(workspace))
         after = set(glob_mod.glob(str(workspace / "*")))
         assert before == after, f"Leftover artifacts: {after - before}"
 
     def test_no_artifacts_on_timeout(self, workspace, timeout_proof):
         """Even on timeout, temp files should be cleaned up."""
         before = set(glob_mod.glob(str(workspace / "*")))
-        rocq_compile(source=timeout_proof, workspace=str(workspace), timeout=3)
+        _call_rocq_compile(source=timeout_proof, workspace=str(workspace), timeout=3)
         after = set(glob_mod.glob(str(workspace / "*")))
         assert before == after, f"Leftover artifacts: {after - before}"
 
@@ -209,7 +222,7 @@ class TestCompileWarningsTruncation:
         )
 
         source = "Theorem t : True. Proof. exact I. Qed."
-        result = rocq_compile(source=source, workspace=str(workspace))
+        result = _call_rocq_compile(source=source, workspace=str(workspace))
 
         assert (
             result["success"] is False
@@ -232,7 +245,7 @@ class TestCompileWarningsTruncation:
         )
 
         source = "Theorem t : True. Proof. exact I. Qed."
-        result = rocq_compile(source=source, workspace=str(workspace))
+        result = _call_rocq_compile(source=source, workspace=str(workspace))
         assert result["success"] is True
 
     def test_empty_stderr_nonzero_returncode(self, workspace, monkeypatch):
@@ -245,7 +258,7 @@ class TestCompileWarningsTruncation:
             lambda *a, **kw: self._make_fake_result(""),
         )
 
-        result = rocq_compile(source="x", workspace=str(workspace))
+        result = _call_rocq_compile(source="x", workspace=str(workspace))
         assert result["success"] is False
         assert "coqc exited with code" in result["error"]
 
@@ -259,7 +272,7 @@ class TestCompileWarningsTruncation:
             lambda *a, **kw: self._make_fake_result("   \n\n  "),
         )
 
-        result = rocq_compile(source="x", workspace=str(workspace))
+        result = _call_rocq_compile(source="x", workspace=str(workspace))
         assert result["success"] is False
         assert "coqc exited with code" in result["error"]
 
@@ -275,7 +288,7 @@ class TestCompileWarningsTruncation:
             lambda *a, **kw: self._make_fake_result(warnings),
         )
 
-        result = rocq_compile(source="x", workspace=str(workspace))
+        result = _call_rocq_compile(source="x", workspace=str(workspace))
         assert result["success"] is False
         assert "Notation overridden" in result["error"]
 
@@ -298,7 +311,7 @@ class TestCompileWarningsTruncation:
             lambda *a, **kw: self._make_fake_result(warn + error),
         )
 
-        result = rocq_compile(
+        result = _call_rocq_compile(
             source="x",
             workspace=str(workspace),
             include_warnings=False,
@@ -326,7 +339,62 @@ class TestCompileWarningsTruncation:
             lambda *a, **kw: self._make_fake_result(warnings + error),
         )
 
-        result = rocq_compile(source="x", workspace=str(workspace))
+        result = _call_rocq_compile(source="x", workspace=str(workspace))
         assert result["success"] is False
         assert "Real error here" in result["error"]
         assert len(result["error"]) <= _compile._MAX_ERROR_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# Wrapper forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestRocqCompileWrapper:
+    """The server wrapper should forward ctx.lifespan_context."""
+
+    pytestmark = []
+
+    def test_ctx_forwarded(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+
+        captured = {}
+
+        async def mock_run_compile_with_state(
+            source,
+            workspace,
+            timeout,
+            include_warnings,
+            lifespan_state=None,
+        ):
+            captured.update(
+                {
+                    "source": source,
+                    "workspace": workspace,
+                    "timeout": timeout,
+                    "include_warnings": include_warnings,
+                    "lifespan_state": lifespan_state,
+                }
+            )
+            return {"success": True, "output": "mock"}
+
+        monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
+        monkeypatch.setattr(_server, "run_compile_with_state", mock_run_compile_with_state)
+
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"pet_client": None}
+
+        result = _call_rocq_compile(
+            source="Check nat.",
+            workspace=str(tmp_path),
+            timeout=7,
+            include_warnings=False,
+            ctx=mock_ctx,
+        )
+
+        assert result["success"] is True
+        assert captured["source"] == "Check nat."
+        assert captured["workspace"] == str(tmp_path)
+        assert captured["timeout"] == 7
+        assert captured["include_warnings"] is False
+        assert captured["lifespan_state"] is mock_ctx.lifespan_context

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -124,9 +124,7 @@ class TestCompileInputValidation:
 
     def test_oversized_source(self, workspace):
         """Source exceeding ROCQ_MAX_SOURCE_SIZE should be rejected early."""
-        result = _call_rocq_compile(
-            source="x" * 2_000_000, workspace=str(workspace)
-        )
+        result = _call_rocq_compile(source="x" * 2_000_000, workspace=str(workspace))
         assert result["success"] is False
         assert "size" in result["error"].lower()
 
@@ -369,16 +367,18 @@ class TestCompileErrorStateCapture:
     ):
         """Successful PET capture should enrich the compile error result."""
         from rocq_mcp import compile as _compile
+        from rocq_mcp import server as _server
 
         stderr = (
             'File "/tmp/tmp.v", line 2, characters 2-9:\n'
-            "Error: The term \"0\" has type \"nat\" while it is expected to have type \"True\".\n"
+            'Error: The term "0" has type "nat" while it is expected to have type "True".\n'
         )
         monkeypatch.setattr(
             _compile,
             "_run_coqc",
             lambda *a, **kw: self._make_fake_result(stderr),
         )
+
         async def _mock_capture_success(*args, **kwargs):
             return {
                 "state_id": 17,
@@ -389,17 +389,19 @@ class TestCompileErrorStateCapture:
             }
 
         monkeypatch.setattr(
-            _compile,
+            _server,
             "_capture_compile_error_state",
             _mock_capture_success,
         )
 
-        result = asyncio.run(_compile.run_compile_with_state(
-            "Theorem bad : True.\n  exact 0.\n",
-            str(workspace),
-            60,
-            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-        ))
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "Theorem bad : True.\n  exact 0.\n",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
 
         assert result["success"] is False
         assert result["state_id"] == 17
@@ -412,6 +414,7 @@ class TestCompileErrorStateCapture:
     def test_warning_before_error_uses_error_position(self, workspace, monkeypatch):
         """State capture must target the first Error, not a preceding Warning."""
         from rocq_mcp import compile as _compile
+        from rocq_mcp import server as _server
 
         stderr = (
             'File "/tmp/tmp.v", line 1, characters 0-5:\n'
@@ -431,14 +434,16 @@ class TestCompileErrorStateCapture:
             captured.update(kwargs)
             return None
 
-        monkeypatch.setattr(_compile, "_capture_compile_error_state", _mock_capture)
+        monkeypatch.setattr(_server, "_capture_compile_error_state", _mock_capture)
 
-        asyncio.run(_compile.run_compile_with_state(
-            "x",
-            str(workspace),
-            60,
-            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-        ))
+        asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
 
         assert captured["line"] == 4
         assert captured["character"] == 3
@@ -446,27 +451,28 @@ class TestCompileErrorStateCapture:
     def test_capture_failure_preserves_existing_hint(self, workspace, monkeypatch):
         """Failed PET capture should fall back to the original compile guidance."""
         from rocq_mcp import compile as _compile
+        from rocq_mcp import server as _server
 
-        stderr = (
-            'File "/tmp/tmp.v", line 2, characters 0-5:\n'
-            "Error: Real failure.\n"
-        )
+        stderr = 'File "/tmp/tmp.v", line 2, characters 0-5:\n' "Error: Real failure.\n"
         monkeypatch.setattr(
             _compile,
             "_run_coqc",
             lambda *a, **kw: self._make_fake_result(stderr),
         )
+
         async def _mock_capture_none(*args, **kwargs):
             return None
 
-        monkeypatch.setattr(_compile, "_capture_compile_error_state", _mock_capture_none)
+        monkeypatch.setattr(_server, "_capture_compile_error_state", _mock_capture_none)
 
-        result = asyncio.run(_compile.run_compile_with_state(
-            "x",
-            str(workspace),
-            60,
-            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-        ))
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
 
         assert result["success"] is False
         assert "state_id" not in result
@@ -507,7 +513,9 @@ class TestRocqCompileWrapper:
             return {"success": True, "output": "mock"}
 
         monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
-        monkeypatch.setattr(_server, "run_compile_with_state", mock_run_compile_with_state)
+        monkeypatch.setattr(
+            _server, "run_compile_with_state", mock_run_compile_with_state
+        )
 
         mock_ctx = MagicMock()
         mock_ctx.lifespan_context = {"pet_client": None}

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -346,6 +346,134 @@ class TestCompileWarningsTruncation:
 
 
 # ---------------------------------------------------------------------------
+# Proof-state capture on compile errors
+# ---------------------------------------------------------------------------
+
+
+class TestCompileErrorStateCapture:
+    """Compile errors should include rocq_start-style state when available."""
+
+    pytestmark = []
+
+    @staticmethod
+    def _make_fake_result(stderr, returncode=1):
+        return {
+            "returncode": returncode,
+            "stdout": "",
+            "stderr": stderr,
+            "timed_out": False,
+        }
+
+    def test_compile_error_includes_state_when_capture_succeeds(
+        self, workspace, monkeypatch
+    ):
+        """Successful PET capture should enrich the compile error result."""
+        from rocq_mcp import compile as _compile
+
+        stderr = (
+            'File "/tmp/tmp.v", line 2, characters 2-9:\n'
+            "Error: The term \"0\" has type \"nat\" while it is expected to have type \"True\".\n"
+        )
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc",
+            lambda *a, **kw: self._make_fake_result(stderr),
+        )
+        async def _mock_capture_success(*args, **kwargs):
+            return {
+                "state_id": 17,
+                "goals": "|- True",
+                "file": "<proof>",
+                "theorem": "@pos(1,2)",
+                "proof_finished": False,
+            }
+
+        monkeypatch.setattr(
+            _compile,
+            "_capture_compile_error_state",
+            _mock_capture_success,
+        )
+
+        result = asyncio.run(_compile.run_compile_with_state(
+            "Theorem bad : True.\n  exact 0.\n",
+            str(workspace),
+            60,
+            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+        ))
+
+        assert result["success"] is False
+        assert result["state_id"] == 17
+        assert result["goals"] == "|- True"
+        assert result["file"] == "<proof>"
+        assert result["theorem"] == "@pos(1,2)"
+        assert result["proof_finished"] is False
+        assert "rocq_check(from_state=17)" in result["hint"]
+
+    def test_warning_before_error_uses_error_position(self, workspace, monkeypatch):
+        """State capture must target the first Error, not a preceding Warning."""
+        from rocq_mcp import compile as _compile
+
+        stderr = (
+            'File "/tmp/tmp.v", line 1, characters 0-5:\n'
+            "Warning: Deprecated.\n"
+            'File "/tmp/tmp.v", line 5, characters 3-11:\n'
+            "Error: Real failure.\n"
+        )
+        captured = {}
+
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc",
+            lambda *a, **kw: self._make_fake_result(stderr),
+        )
+
+        async def _mock_capture(*args, **kwargs):
+            captured.update(kwargs)
+            return None
+
+        monkeypatch.setattr(_compile, "_capture_compile_error_state", _mock_capture)
+
+        asyncio.run(_compile.run_compile_with_state(
+            "x",
+            str(workspace),
+            60,
+            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+        ))
+
+        assert captured["line"] == 4
+        assert captured["character"] == 3
+
+    def test_capture_failure_preserves_existing_hint(self, workspace, monkeypatch):
+        """Failed PET capture should fall back to the original compile guidance."""
+        from rocq_mcp import compile as _compile
+
+        stderr = (
+            'File "/tmp/tmp.v", line 2, characters 0-5:\n'
+            "Error: Real failure.\n"
+        )
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc",
+            lambda *a, **kw: self._make_fake_result(stderr),
+        )
+        async def _mock_capture_none(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(_compile, "_capture_compile_error_state", _mock_capture_none)
+
+        result = asyncio.run(_compile.run_compile_with_state(
+            "x",
+            str(workspace),
+            60,
+            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+        ))
+
+        assert result["success"] is False
+        assert "state_id" not in result
+        assert "Use rocq_start" in result["hint"]
+
+
+# ---------------------------------------------------------------------------
 # Wrapper forwarding
 # ---------------------------------------------------------------------------
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -12,11 +12,16 @@ from __future__ import annotations
 
 import asyncio
 import glob as glob_mod
-from unittest.mock import MagicMock
-
 import pytest
 
-from tests.conftest import COQC_AVAILABLE
+from tests.conftest import (
+    COQC_AVAILABLE,
+    _DEFAULT_STDERR,
+    _MockContext,
+    _fake_coqc_result,
+    _patch_capture_position_state,
+    _patch_compile_error,
+)
 from rocq_mcp.server import rocq_compile
 
 pytestmark = pytest.mark.skipif(not COQC_AVAILABLE, reason="coqc not available")
@@ -345,96 +350,45 @@ class TestCompileWarningsTruncation:
 
 # ---------------------------------------------------------------------------
 # Proof-state capture on compile errors
+#
+# These tests exercise the orchestration path
+#     run_compile_with_state -> _capture_compile_error_state
+#                              -> capture_position_state (mocked)
+#                              -> _merge_compile_error_state
+# All mocks attach at ``capture_position_state`` (the boundary between the
+# orchestrator and the PET subprocess) so that the status-derivation logic
+# inside ``_capture_compile_error_state`` is actually exercised.
+#
+# ``_fake_coqc_result``, ``_patch_compile_error``,
+# ``_patch_capture_position_state``, and ``_DEFAULT_STDERR`` live in
+# ``tests/conftest.py`` so they are reusable across compile / compile_file
+# test modules.
 # ---------------------------------------------------------------------------
 
 
-class TestCompileErrorStateCapture:
-    """Compile errors should include rocq_start-style state when available."""
+class TestStateCaptureStatus:
+    """Status-derivation tests: mock ``capture_position_state``, not higher."""
 
     pytestmark = []
 
-    @staticmethod
-    def _make_fake_result(stderr, returncode=1):
-        return {
-            "returncode": returncode,
-            "stdout": "",
-            "stderr": stderr,
-            "timed_out": False,
-        }
-
-    def test_compile_error_includes_state_when_capture_succeeds(
-        self, workspace, monkeypatch
-    ):
-        """Successful PET capture should enrich the compile error result."""
-        from rocq_mcp import compile as _compile
-        from rocq_mcp import server as _server
-
-        stderr = (
-            'File "/tmp/tmp.v", line 2, characters 2-9:\n'
-            'Error: The term "0" has type "nat" while it is expected to have type "True".\n'
-        )
-        monkeypatch.setattr(
-            _compile,
-            "_run_coqc",
-            lambda *a, **kw: self._make_fake_result(stderr),
-        )
-
-        async def _mock_capture_success(*args, **kwargs):
-            return {
-                "state_id": 17,
-                "goals": "|- True",
-                "file": "<proof>",
-                "theorem": "@pos(1,2)",
-                "proof_finished": False,
-            }
-
-        monkeypatch.setattr(
-            _server,
-            "_capture_compile_error_state",
-            _mock_capture_success,
-        )
-
-        result = asyncio.run(
-            _server.run_compile_with_state(
-                "Theorem bad : True.\n  exact 0.\n",
-                str(workspace),
-                60,
-                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-            )
-        )
-
-        assert result["success"] is False
-        assert result["state_id"] == 17
-        assert result["goals"] == "|- True"
-        assert result["file"] == "<proof>"
-        assert result["theorem"] == "@pos(1,2)"
-        assert result["proof_finished"] is False
-        assert "rocq_check(from_state=17)" in result["hint"]
-
     def test_warning_before_error_uses_error_position(self, workspace, monkeypatch):
         """State capture must target the first Error, not a preceding Warning."""
-        from rocq_mcp import compile as _compile
-        from rocq_mcp import server as _server
-
         stderr = (
             'File "/tmp/tmp.v", line 1, characters 0-5:\n'
             "Warning: Deprecated.\n"
             'File "/tmp/tmp.v", line 5, characters 3-11:\n'
             "Error: Real failure.\n"
         )
-        captured = {}
+        _patch_compile_error(monkeypatch, stderr)
+        from rocq_mcp import server as _server
 
-        monkeypatch.setattr(
-            _compile,
-            "_run_coqc",
-            lambda *a, **kw: self._make_fake_result(stderr),
-        )
+        captured: dict = {}
 
-        async def _mock_capture(*args, **kwargs):
+        async def _mock_cps(**kwargs):
             captured.update(kwargs)
-            return None
+            return {"success": False, "error": "boom", "pet_restarted": True}
 
-        monkeypatch.setattr(_server, "_capture_compile_error_state", _mock_capture)
+        _patch_capture_position_state(monkeypatch, _mock_cps)
 
         asyncio.run(
             _server.run_compile_with_state(
@@ -445,25 +399,207 @@ class TestCompileErrorStateCapture:
             )
         )
 
+        # First Error is on the second diagnostic block: line 5 (1-based)
+        # -> 4 (0-based); character 3.
         assert captured["line"] == 4
         assert captured["character"] == 3
 
-    def test_capture_failure_preserves_existing_hint(self, workspace, monkeypatch):
-        """Failed PET capture should fall back to the original compile guidance."""
+    def test_status_timeout_when_pet_times_out(self, workspace, monkeypatch):
+        """capture_position_state returning a timeout dict -> status='timeout'."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        async def _mock_cps(**kwargs):
+            return {
+                "success": False,
+                "error": "Compile error state capture timed out after 5.0s.",
+                "pet_restarted": True,
+                "reason": "timeout",
+            }
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "timeout"
+        assert "state_id" not in result
+        assert "Real failure" in result["error"]
+        assert "Use rocq_start" in result["hint"]
+
+    def test_status_crashed_when_pet_restarts(self, workspace, monkeypatch):
+        """capture_position_state returning a crash dict -> status='crashed'."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        async def _mock_cps(**kwargs):
+            return {
+                "success": False,
+                "error": "Pet process died: BrokenPipeError",
+                "pet_restarted": True,
+                "reason": "crashed",
+            }
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "crashed"
+        assert "state_id" not in result
+        assert "Real failure" in result["error"]
+
+    def test_status_lock_contended_when_pet_busy(self, workspace, monkeypatch):
+        """capture_position_state returning a lock-contention dict -> status='lock_contended'."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        async def _mock_cps(**kwargs):
+            return {
+                "success": False,
+                "error": (
+                    "Compile error state capture: pet is busy "
+                    "(lock contention). Try again."
+                ),
+                "reason": "lock_contended",
+            }
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "lock_contended"
+        assert "state_id" not in result
+        assert "Real failure" in result["error"]
+        assert "Use rocq_start" in result["hint"]
+
+    def test_status_unavailable_when_pet_not_installed(self, workspace, monkeypatch):
+        """capture_position_state returning reason='unavailable' -> status='unavailable'."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        async def _mock_cps(**kwargs):
+            return {
+                "success": False,
+                "error": (
+                    "pytanque is not installed. "
+                    "Install with: pip install 'rocq-mcp[interactive]'"
+                ),
+                "reason": "unavailable",
+            }
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "unavailable"
+        assert "state_id" not in result
+
+    def test_status_defaults_to_crashed_when_no_reason(self, workspace, monkeypatch):
+        """A failure dict with no ``reason`` key falls back to status='crashed'."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        async def _mock_cps(**kwargs):
+            return {
+                "success": False,
+                "error": "Pet died unexpectedly",
+            }
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "crashed"
+        assert "state_id" not in result
+
+    def test_status_unavailable_when_import_fails(self, workspace, monkeypatch):
+        """Forced ImportError on rocq_mcp.interactive -> status='unavailable'."""
+        import sys
+
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        # Setting the module to None makes ``from rocq_mcp.interactive import ...``
+        # raise ImportError at runtime.
+        monkeypatch.setitem(sys.modules, "rocq_mcp.interactive", None)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "unavailable"
+        assert "state_id" not in result
+        assert "Use rocq_start" in result["hint"]
+
+    def test_status_no_position_when_no_error_positions(self, workspace, monkeypatch):
+        """When the coqc result lacks ``error_positions`` capture is not attempted."""
         from rocq_mcp import compile as _compile
         from rocq_mcp import server as _server
 
-        stderr = 'File "/tmp/tmp.v", line 2, characters 0-5:\n' "Error: Real failure.\n"
+        # stderr that produces no File-line entries -> _format_error returns
+        # empty -> _build_compile_result falls through to the no-position
+        # fallback (no ``error_positions`` key in the result dict).
         monkeypatch.setattr(
             _compile,
             "_run_coqc",
-            lambda *a, **kw: self._make_fake_result(stderr),
+            lambda *a, **kw: _fake_coqc_result(
+                "Toplevel: unstructured error, no File-line marker.\n"
+            ),
         )
 
-        async def _mock_capture_none(*args, **kwargs):
-            return None
+        called = {"hit": False}
 
-        monkeypatch.setattr(_server, "_capture_compile_error_state", _mock_capture_none)
+        async def _mock_cps(**kwargs):
+            called["hit"] = True
+            return {
+                "success": True,
+                "state_id": 1,
+                "goals": "|- True",
+                "file": "<proof>",
+                "theorem": "@pos(0,0)",
+                "proof_finished": False,
+            }
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
 
         result = asyncio.run(
             _server.run_compile_with_state(
@@ -475,8 +611,115 @@ class TestCompileErrorStateCapture:
         )
 
         assert result["success"] is False
+        assert result["state_capture_status"] == "no_position"
+        assert "state_id" not in result
+        assert called["hit"] is False, "capture must not run when no error_positions"
+
+    def test_status_crashed_when_temp_file_io_fails(self, workspace, monkeypatch):
+        """OSError on tempfile creation -> status='crashed', capture not invoked."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        called = {"hit": False}
+
+        async def _mock_cps(**kwargs):
+            called["hit"] = True
+            return {"success": True, "state_id": 1, "goals": "|- True"}
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        def _raise_oserror(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(_server.tempfile, "NamedTemporaryFile", _raise_oserror)
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["state_capture_status"] == "crashed"
         assert "state_id" not in result
         assert "Use rocq_start" in result["hint"]
+        assert called["hit"] is False
+
+    def test_no_status_field_on_success(self, workspace, monkeypatch):
+        """Successful compile must not carry state_capture_status."""
+        from rocq_mcp import compile as _compile
+        from rocq_mcp import server as _server
+
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc",
+            lambda *a, **kw: _fake_coqc_result("", returncode=0),
+        )
+
+        result = asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["success"] is True
+        assert "state_capture_status" not in result
+
+    def test_enrichment_timeout_capped_at_5s(self, workspace, monkeypatch):
+        """The capture-side timeout must be min(pet_timeout, 5.0)."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        recorded: dict = {}
+
+        async def _mock_cps(**kwargs):
+            recorded["timeout"] = kwargs.get("timeout")
+            return {"success": False, "error": "boom", "pet_restarted": True}
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                # pet_timeout 30 must be capped to 5.0 by the orchestration.
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert recorded["timeout"] == 5.0
+
+    def test_enrichment_timeout_floor_when_pet_timeout_below_cap(
+        self, workspace, monkeypatch
+    ):
+        """When pet_timeout < 5.0, the recorded timeout is the lower pet_timeout."""
+        _patch_compile_error(monkeypatch, _DEFAULT_STDERR)
+        from rocq_mcp import server as _server
+
+        recorded: dict = {}
+
+        async def _mock_cps(**kwargs):
+            recorded["timeout"] = kwargs.get("timeout")
+            return {"success": False, "error": "boom", "pet_restarted": True}
+
+        _patch_capture_position_state(monkeypatch, _mock_cps)
+
+        asyncio.run(
+            _server.run_compile_with_state(
+                "x",
+                str(workspace),
+                60,
+                lifespan_state={"pet_client": None, "pet_timeout": 2.0},
+            )
+        )
+
+        assert recorded["timeout"] == 2.0
 
 
 # ---------------------------------------------------------------------------
@@ -517,8 +760,7 @@ class TestRocqCompileWrapper:
             _server, "run_compile_with_state", mock_run_compile_with_state
         )
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"pet_client": None}
+        mock_ctx = _MockContext({"pet_client": None})
 
         result = _call_rocq_compile(
             source="Check nat.",

--- a/tests/test_compile_file.py
+++ b/tests/test_compile_file.py
@@ -237,6 +237,104 @@ class TestCompileFileStructuredErrors:
 
 
 # ---------------------------------------------------------------------------
+# Proof-state capture on compile errors
+# ---------------------------------------------------------------------------
+
+
+class TestCompileFileErrorStateCapture:
+    """Compile-file errors should include rocq_start-style state when available."""
+
+    pytestmark = []
+
+    @staticmethod
+    def _make_fake_result(stderr, returncode=1):
+        return {
+            "returncode": returncode,
+            "stdout": "",
+            "stderr": stderr,
+            "timed_out": False,
+        }
+
+    def test_compile_file_error_includes_state_when_capture_succeeds(
+        self, workspace, monkeypatch
+    ):
+        import rocq_mcp.compile as _compile
+
+        path = workspace / "capture_test.v"
+        path.write_text("Theorem bad : True.\n  exact 0.\n")
+        stderr = (
+            'File "capture_test.v", line 2, characters 2-9:\n'
+            "Error: The term \"0\" has type \"nat\" while it is expected to have type \"True\".\n"
+        )
+
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc_file",
+            lambda *a, **kw: self._make_fake_result(stderr),
+        )
+        async def _mock_capture_success(*args, **kwargs):
+            return {
+                "state_id": 23,
+                "goals": "|- True",
+                "file": "capture_test.v",
+                "theorem": "@pos(1,2)",
+                "proof_finished": False,
+            }
+
+        monkeypatch.setattr(
+            _compile,
+            "_capture_compile_error_state",
+            _mock_capture_success,
+        )
+
+        result = asyncio.run(_compile.run_compile_file_with_state(
+            file="capture_test.v",
+            workspace=str(workspace),
+            timeout=60,
+            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+        ))
+
+        assert result["success"] is False
+        assert result["state_id"] == 23
+        assert result["file"] == "capture_test.v"
+        assert result["theorem"] == "@pos(1,2)"
+        assert "rocq_check(from_state=23)" in result["hint"]
+
+    def test_compile_file_capture_receives_resolved_path(self, workspace, monkeypatch):
+        import rocq_mcp.compile as _compile
+
+        path = workspace / "resolved_path_test.v"
+        path.write_text("Theorem bad : True.\n  exact 0.\n")
+        stderr = (
+            'File "resolved_path_test.v", line 2, characters 1-8:\n'
+            "Error: Real failure.\n"
+        )
+        captured = {}
+
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc_file",
+            lambda *a, **kw: self._make_fake_result(stderr),
+        )
+
+        async def _mock_capture(*args, **kwargs):
+            captured.update(kwargs)
+            return None
+
+        monkeypatch.setattr(_compile, "_capture_compile_error_state", _mock_capture)
+
+        asyncio.run(_compile.run_compile_file_with_state(
+            file="resolved_path_test.v",
+            workspace=str(workspace),
+            timeout=60,
+            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+        ))
+
+        assert captured["file_label"] == "resolved_path_test.v"
+        assert captured["resolved_file"] == str(path.resolve())
+
+
+# ---------------------------------------------------------------------------
 # Wrapper forwarding
 # ---------------------------------------------------------------------------
 
@@ -280,19 +378,17 @@ class TestRocqCompileFileWrapper:
         mock_ctx = MagicMock()
         mock_ctx.lifespan_context = {"pet_client": None}
 
-        result = asyncio.run(
-            rocq_compile_file(
-                file="demo.v",
-                workspace=str(tmp_path),
-                timeout=7,
-                include_warnings=False,
-                ctx=mock_ctx,
-            )
-        )
+        result = asyncio.run(rocq_compile_file(
+            file="proof.v",
+            workspace=str(tmp_path),
+            timeout=9,
+            include_warnings=False,
+            ctx=mock_ctx,
+        ))
 
         assert result["success"] is True
-        assert captured["file"] == "demo.v"
+        assert captured["file"] == "proof.v"
         assert captured["workspace"] == str(tmp_path)
-        assert captured["timeout"] == 7
+        assert captured["timeout"] == 9
         assert captured["include_warnings"] is False
         assert captured["lifespan_state"] is mock_ctx.lifespan_context

--- a/tests/test_compile_file.py
+++ b/tests/test_compile_file.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import glob as glob_mod
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -233,3 +234,65 @@ class TestCompileFileStructuredErrors:
         )
         assert result["success"] is False
         assert "hint" in result
+
+
+# ---------------------------------------------------------------------------
+# Wrapper forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestRocqCompileFileWrapper:
+    """The server wrapper should forward ctx.lifespan_context."""
+
+    pytestmark = []
+
+    def test_ctx_forwarded(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from rocq_mcp.server import rocq_compile_file
+
+        captured = {}
+
+        async def mock_run_compile_file_with_state(
+            file,
+            workspace,
+            timeout,
+            include_warnings,
+            lifespan_state=None,
+        ):
+            captured.update(
+                {
+                    "file": file,
+                    "workspace": workspace,
+                    "timeout": timeout,
+                    "include_warnings": include_warnings,
+                    "lifespan_state": lifespan_state,
+                }
+            )
+            return {"success": True, "output": "mock"}
+
+        monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
+        monkeypatch.setattr(
+            _server,
+            "run_compile_file_with_state",
+            mock_run_compile_file_with_state,
+        )
+
+        mock_ctx = MagicMock()
+        mock_ctx.lifespan_context = {"pet_client": None}
+
+        result = asyncio.run(
+            rocq_compile_file(
+                file="demo.v",
+                workspace=str(tmp_path),
+                timeout=7,
+                include_warnings=False,
+                ctx=mock_ctx,
+            )
+        )
+
+        assert result["success"] is True
+        assert captured["file"] == "demo.v"
+        assert captured["workspace"] == str(tmp_path)
+        assert captured["timeout"] == 7
+        assert captured["include_warnings"] is False
+        assert captured["lifespan_state"] is mock_ctx.lifespan_context

--- a/tests/test_compile_file.py
+++ b/tests/test_compile_file.py
@@ -259,12 +259,13 @@ class TestCompileFileErrorStateCapture:
         self, workspace, monkeypatch
     ):
         import rocq_mcp.compile as _compile
+        import rocq_mcp.server as _server
 
         path = workspace / "capture_test.v"
         path.write_text("Theorem bad : True.\n  exact 0.\n")
         stderr = (
             'File "capture_test.v", line 2, characters 2-9:\n'
-            "Error: The term \"0\" has type \"nat\" while it is expected to have type \"True\".\n"
+            'Error: The term "0" has type "nat" while it is expected to have type "True".\n'
         )
 
         monkeypatch.setattr(
@@ -272,6 +273,7 @@ class TestCompileFileErrorStateCapture:
             "_run_coqc_file",
             lambda *a, **kw: self._make_fake_result(stderr),
         )
+
         async def _mock_capture_success(*args, **kwargs):
             return {
                 "state_id": 23,
@@ -282,17 +284,19 @@ class TestCompileFileErrorStateCapture:
             }
 
         monkeypatch.setattr(
-            _compile,
+            _server,
             "_capture_compile_error_state",
             _mock_capture_success,
         )
 
-        result = asyncio.run(_compile.run_compile_file_with_state(
-            file="capture_test.v",
-            workspace=str(workspace),
-            timeout=60,
-            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-        ))
+        result = asyncio.run(
+            _server.run_compile_file_with_state(
+                file="capture_test.v",
+                workspace=str(workspace),
+                timeout=60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
 
         assert result["success"] is False
         assert result["state_id"] == 23
@@ -302,6 +306,7 @@ class TestCompileFileErrorStateCapture:
 
     def test_compile_file_capture_receives_resolved_path(self, workspace, monkeypatch):
         import rocq_mcp.compile as _compile
+        import rocq_mcp.server as _server
 
         path = workspace / "resolved_path_test.v"
         path.write_text("Theorem bad : True.\n  exact 0.\n")
@@ -321,14 +326,16 @@ class TestCompileFileErrorStateCapture:
             captured.update(kwargs)
             return None
 
-        monkeypatch.setattr(_compile, "_capture_compile_error_state", _mock_capture)
+        monkeypatch.setattr(_server, "_capture_compile_error_state", _mock_capture)
 
-        asyncio.run(_compile.run_compile_file_with_state(
-            file="resolved_path_test.v",
-            workspace=str(workspace),
-            timeout=60,
-            lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-        ))
+        asyncio.run(
+            _server.run_compile_file_with_state(
+                file="resolved_path_test.v",
+                workspace=str(workspace),
+                timeout=60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
 
         assert captured["file_label"] == "resolved_path_test.v"
         assert captured["resolved_file"] == str(path.resolve())
@@ -378,13 +385,15 @@ class TestRocqCompileFileWrapper:
         mock_ctx = MagicMock()
         mock_ctx.lifespan_context = {"pet_client": None}
 
-        result = asyncio.run(rocq_compile_file(
-            file="proof.v",
-            workspace=str(tmp_path),
-            timeout=9,
-            include_warnings=False,
-            ctx=mock_ctx,
-        ))
+        result = asyncio.run(
+            rocq_compile_file(
+                file="proof.v",
+                workspace=str(tmp_path),
+                timeout=9,
+                include_warnings=False,
+                ctx=mock_ctx,
+            )
+        )
 
         assert result["success"] is True
         assert captured["file"] == "proof.v"

--- a/tests/test_compile_file.py
+++ b/tests/test_compile_file.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import glob as glob_mod
-from unittest.mock import MagicMock, patch
-
 import pytest
 
-from tests.conftest import COQC_AVAILABLE
+from tests.conftest import COQC_AVAILABLE, _MockContext, _fake_coqc_result
 from rocq_mcp.compile import run_compile_file
 
 pytestmark = pytest.mark.skipif(not COQC_AVAILABLE, reason="coqc not available")
@@ -242,70 +240,20 @@ class TestCompileFileStructuredErrors:
 
 
 class TestCompileFileErrorStateCapture:
-    """Compile-file errors should include rocq_start-style state when available."""
+    """Compile-file orchestration: only the file-path-specific behaviours.
+
+    Status-derivation logic is exercised by ``test_compile.TestStateCaptureStatus``
+    via the inline-source path; the file-path code path shares the same
+    ``_capture_compile_error_state`` machinery, so we only assert here the
+    file-resolution glue (resolved_file, file_label).
+    """
 
     pytestmark = []
 
-    @staticmethod
-    def _make_fake_result(stderr, returncode=1):
-        return {
-            "returncode": returncode,
-            "stdout": "",
-            "stderr": stderr,
-            "timed_out": False,
-        }
-
-    def test_compile_file_error_includes_state_when_capture_succeeds(
-        self, workspace, monkeypatch
-    ):
-        import rocq_mcp.compile as _compile
-        import rocq_mcp.server as _server
-
-        path = workspace / "capture_test.v"
-        path.write_text("Theorem bad : True.\n  exact 0.\n")
-        stderr = (
-            'File "capture_test.v", line 2, characters 2-9:\n'
-            'Error: The term "0" has type "nat" while it is expected to have type "True".\n'
-        )
-
-        monkeypatch.setattr(
-            _compile,
-            "_run_coqc_file",
-            lambda *a, **kw: self._make_fake_result(stderr),
-        )
-
-        async def _mock_capture_success(*args, **kwargs):
-            return {
-                "state_id": 23,
-                "goals": "|- True",
-                "file": "capture_test.v",
-                "theorem": "@pos(1,2)",
-                "proof_finished": False,
-            }
-
-        monkeypatch.setattr(
-            _server,
-            "_capture_compile_error_state",
-            _mock_capture_success,
-        )
-
-        result = asyncio.run(
-            _server.run_compile_file_with_state(
-                file="capture_test.v",
-                workspace=str(workspace),
-                timeout=60,
-                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
-            )
-        )
-
-        assert result["success"] is False
-        assert result["state_id"] == 23
-        assert result["file"] == "capture_test.v"
-        assert result["theorem"] == "@pos(1,2)"
-        assert "rocq_check(from_state=23)" in result["hint"]
-
     def test_compile_file_capture_receives_resolved_path(self, workspace, monkeypatch):
+        """The resolved path and file_label flow through to capture_position_state."""
         import rocq_mcp.compile as _compile
+        import rocq_mcp.interactive as _interactive
         import rocq_mcp.server as _server
 
         path = workspace / "resolved_path_test.v"
@@ -319,14 +267,14 @@ class TestCompileFileErrorStateCapture:
         monkeypatch.setattr(
             _compile,
             "_run_coqc_file",
-            lambda *a, **kw: self._make_fake_result(stderr),
+            lambda *a, **kw: _fake_coqc_result(stderr),
         )
 
-        async def _mock_capture(*args, **kwargs):
+        async def _mock_cps(**kwargs):
             captured.update(kwargs)
-            return None
+            return {"success": False, "error": "boom", "pet_restarted": True}
 
-        monkeypatch.setattr(_server, "_capture_compile_error_state", _mock_capture)
+        monkeypatch.setattr(_interactive, "capture_position_state", _mock_cps)
 
         asyncio.run(
             _server.run_compile_file_with_state(
@@ -337,8 +285,45 @@ class TestCompileFileErrorStateCapture:
             )
         )
 
-        assert captured["file_label"] == "resolved_path_test.v"
+        assert captured["file"] == "resolved_path_test.v"
         assert captured["resolved_file"] == str(path.resolve())
+
+    def test_status_no_position_when_path_resolution_fails(
+        self, workspace, monkeypatch
+    ):
+        """A path that escapes the workspace short-circuits with status='no_position'."""
+        import rocq_mcp.compile as _compile
+        import rocq_mcp.interactive as _interactive
+        import rocq_mcp.server as _server
+
+        stderr = "Error: nonsense.\n"
+        cps_called = {"called": False}
+
+        monkeypatch.setattr(
+            _compile,
+            "_run_coqc_file",
+            lambda *a, **kw: _fake_coqc_result(stderr),
+        )
+
+        async def _mock_cps(**kwargs):
+            cps_called["called"] = True
+            return {"success": False, "error": "should not be reached"}
+
+        monkeypatch.setattr(_interactive, "capture_position_state", _mock_cps)
+
+        result = asyncio.run(
+            _server.run_compile_file_with_state(
+                file="../escaping_path.v",
+                workspace=str(workspace),
+                timeout=60,
+                lifespan_state={"pet_client": None, "pet_timeout": 30.0},
+            )
+        )
+
+        assert result["success"] is False
+        assert result["state_capture_status"] == "no_position"
+        assert "state_id" not in result
+        assert cps_called["called"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -382,8 +367,7 @@ class TestRocqCompileFileWrapper:
             mock_run_compile_file_with_state,
         )
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"pet_client": None}
+        mock_ctx = _MockContext({"pet_client": None})
 
         result = asyncio.run(
             rocq_compile_file(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -331,6 +331,113 @@ class _MockContext:
 
 @pytest.mark.skipif(
     not (COQC_AVAILABLE and PET_AVAILABLE),
+    reason="coqc and pet required for compile error state capture",
+)
+class TestCompileErrorStateWorkflow:
+    """End-to-end: compile errors should include the current proof state."""
+
+    @pytest.fixture
+    def lifespan_state(self):
+        from rocq_mcp.server import _invalidate_pet
+
+        state = {"pet_client": None, "pet_timeout": 30.0, "current_workspace": None}
+        yield state
+        _invalidate_pet(state)
+
+    async def test_compile_includes_error_state(self, lifespan_state, workspace):
+        """rocq_compile should attach a recoverable state at the error position."""
+        from rocq_mcp.server import rocq_compile
+
+        source = (
+            "Theorem bad : True.\n"
+            "Proof.\n"
+            "  exact 0.\n"
+            "Qed.\n"
+        )
+        ctx = _MockContext(lifespan_state)
+
+        result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
+
+        assert result["success"] is False
+        assert isinstance(result["state_id"], int)
+        assert result["goals"] == "\n|-True"
+        assert result["file"] == "<proof>"
+        assert result["theorem"] == "@pos(2,8)"
+        assert result["proof_finished"] is False
+
+    async def test_compile_file_includes_error_state(self, lifespan_state, workspace):
+        """rocq_compile_file should attach a recoverable state at the error position."""
+        from rocq_mcp.server import rocq_compile_file
+
+        path = workspace / "error_state_test.v"
+        path.write_text(
+            "Theorem bad : True.\n"
+            "Proof.\n"
+            "  exact 0.\n"
+            "Qed.\n"
+        )
+        ctx = _MockContext(lifespan_state)
+
+        result = await rocq_compile_file(
+            file="error_state_test.v",
+            workspace=str(workspace),
+            ctx=ctx,
+        )
+
+        assert result["success"] is False
+        assert isinstance(result["state_id"], int)
+        assert result["goals"] == "\n|-True"
+        assert result["file"] == "error_state_test.v"
+        assert result["theorem"] == "@pos(2,8)"
+        assert result["proof_finished"] is False
+
+    async def test_compile_with_assumption_includes_goal_context(
+        self, lifespan_state, workspace
+    ):
+        """Captured goals should include local assumptions from the proof state."""
+        from rocq_mcp.server import rocq_compile
+
+        source = (
+            "Lemma bad (n : nat) : True.\n"
+            "Proof.\n"
+            "  exact 0.\n"
+            "Qed.\n"
+        )
+        ctx = _MockContext(lifespan_state)
+
+        result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
+
+        assert result["success"] is False
+        assert result["goals"] == "n : nat\n|-True"
+        assert result["file"] == "<proof>"
+        assert result["theorem"] == "@pos(2,8)"
+        assert result["proof_finished"] is False
+
+    async def test_compile_multiple_tactics_same_line_uses_later_error_position(
+        self, lifespan_state, workspace
+    ):
+        """Error-state capture should point after earlier successful tactics."""
+        from rocq_mcp.server import rocq_compile
+
+        source = (
+            "Lemma bad (n : nat) : True.\n"
+            "Proof.\n"
+            "  idtac. exact 0.\n"
+            "Qed.\n"
+        )
+        ctx = _MockContext(lifespan_state)
+
+        result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
+
+        assert result["success"] is False
+        assert result["goals"] == "n : nat\n|-True"
+        assert result["file"] == "<proof>"
+        assert result["theorem"] == "@pos(2,15)"
+        assert result["proof_finished"] is False
+
+
+@pytest.mark.skipif(
+    not (COQC_AVAILABLE and PET_AVAILABLE),
     reason="coqc and pet required for Phase 2 verification",
 )
 class TestSharedDefsVerifyWorkflow:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import glob as glob_mod
+import re
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,7 @@ def _call_rocq_compile(**kwargs):
     from rocq_mcp.server import rocq_compile
 
     return asyncio.run(rocq_compile(**kwargs))
+
 
 # =========================================================================
 # Compile -> Verify workflow (Phase 0)
@@ -348,21 +350,18 @@ class TestCompileErrorStateWorkflow:
         """rocq_compile should attach a recoverable state at the error position."""
         from rocq_mcp.server import rocq_compile
 
-        source = (
-            "Theorem bad : True.\n"
-            "Proof.\n"
-            "  exact 0.\n"
-            "Qed.\n"
-        )
+        source = "Theorem bad : True.\n" "Proof.\n" "  exact 0.\n" "Qed.\n"
         ctx = _MockContext(lifespan_state)
 
         result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
 
         assert result["success"] is False
         assert isinstance(result["state_id"], int)
-        assert result["goals"] == "\n|-True"
+        assert "|-True" in result["goals"]
         assert result["file"] == "<proof>"
-        assert result["theorem"] == "@pos(2,8)"
+        # Position is on line 2 (0-indexed: the `exact 0.` line);
+        # the column is set by coqc and may shift across Rocq versions.
+        assert result["theorem"].startswith("@pos(2,")
         assert result["proof_finished"] is False
 
     async def test_compile_file_includes_error_state(self, lifespan_state, workspace):
@@ -370,12 +369,7 @@ class TestCompileErrorStateWorkflow:
         from rocq_mcp.server import rocq_compile_file
 
         path = workspace / "error_state_test.v"
-        path.write_text(
-            "Theorem bad : True.\n"
-            "Proof.\n"
-            "  exact 0.\n"
-            "Qed.\n"
-        )
+        path.write_text("Theorem bad : True.\n" "Proof.\n" "  exact 0.\n" "Qed.\n")
         ctx = _MockContext(lifespan_state)
 
         result = await rocq_compile_file(
@@ -386,9 +380,9 @@ class TestCompileErrorStateWorkflow:
 
         assert result["success"] is False
         assert isinstance(result["state_id"], int)
-        assert result["goals"] == "\n|-True"
+        assert "|-True" in result["goals"]
         assert result["file"] == "error_state_test.v"
-        assert result["theorem"] == "@pos(2,8)"
+        assert result["theorem"].startswith("@pos(2,")
         assert result["proof_finished"] is False
 
     async def test_compile_with_assumption_includes_goal_context(
@@ -397,20 +391,16 @@ class TestCompileErrorStateWorkflow:
         """Captured goals should include local assumptions from the proof state."""
         from rocq_mcp.server import rocq_compile
 
-        source = (
-            "Lemma bad (n : nat) : True.\n"
-            "Proof.\n"
-            "  exact 0.\n"
-            "Qed.\n"
-        )
+        source = "Lemma bad (n : nat) : True.\n" "Proof.\n" "  exact 0.\n" "Qed.\n"
         ctx = _MockContext(lifespan_state)
 
         result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
 
         assert result["success"] is False
-        assert result["goals"] == "n : nat\n|-True"
+        assert "n : nat" in result["goals"]
+        assert "|-True" in result["goals"]
         assert result["file"] == "<proof>"
-        assert result["theorem"] == "@pos(2,8)"
+        assert result["theorem"].startswith("@pos(2,")
         assert result["proof_finished"] is False
 
     async def test_compile_multiple_tactics_same_line_uses_later_error_position(
@@ -420,19 +410,27 @@ class TestCompileErrorStateWorkflow:
         from rocq_mcp.server import rocq_compile
 
         source = (
-            "Lemma bad (n : nat) : True.\n"
-            "Proof.\n"
-            "  idtac. exact 0.\n"
-            "Qed.\n"
+            "Lemma bad (n : nat) : True.\n" "Proof.\n" "  idtac. exact 0.\n" "Qed.\n"
         )
         ctx = _MockContext(lifespan_state)
 
         result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
 
         assert result["success"] is False
-        assert result["goals"] == "n : nat\n|-True"
+        assert "n : nat" in result["goals"]
+        assert "|-True" in result["goals"]
         assert result["file"] == "<proof>"
-        assert result["theorem"] == "@pos(2,15)"
+        # Capture must point on line 2 and *after* the prior `idtac.` so
+        # the goal reflects the earlier successful tactic.  The exact
+        # column is coqc-reported and may shift across Rocq versions.
+        m = re.match(r"@pos\((\d+),(\d+)\)", result["theorem"])
+        assert m, f"theorem should be @pos(line,col), got {result['theorem']!r}"
+        line, col = int(m.group(1)), int(m.group(2))
+        assert line == 2
+        assert col > len("  idtac."), (
+            f"position should be past 'idtac.' (col >{len('  idtac.')}), "
+            f"got col={col}"
+        )
         assert result["proof_finished"] is False
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,12 +7,20 @@ TestQueryStepWorkflow: query then start+check (require pet)
 
 from __future__ import annotations
 
+import asyncio
 import glob as glob_mod
 from pathlib import Path
 
 import pytest
 
 from tests.conftest import COQC_AVAILABLE, PET_AVAILABLE
+
+
+def _call_rocq_compile(**kwargs):
+    """Run the async server wrapper from synchronous tests."""
+    from rocq_mcp.server import rocq_compile
+
+    return asyncio.run(rocq_compile(**kwargs))
 
 # =========================================================================
 # Compile -> Verify workflow (Phase 0)
@@ -29,7 +37,9 @@ class TestCompileVerifyWorkflow:
         """Full happy path: compile succeeds -> verify succeeds."""
         from rocq_mcp.server import rocq_compile, rocq_verify
 
-        compile_result = rocq_compile(source=simple_proof, workspace=str(workspace))
+        compile_result = await rocq_compile(
+            source=simple_proof, workspace=str(workspace)
+        )
         assert compile_result["success"] is True
 
         verify_result = await rocq_verify(
@@ -46,7 +56,9 @@ class TestCompileVerifyWorkflow:
         """Cheat is rejected: either compilation fails or verify catches it."""
         from rocq_mcp.server import rocq_compile, rocq_verify
 
-        compile_result = rocq_compile(source=cheating_proof, workspace=str(workspace))
+        compile_result = await rocq_compile(
+            source=cheating_proof, workspace=str(workspace)
+        )
         # The cheat may or may not compile (depends on exact Rocq version).
         # If compilation already rejects it, the cheat is caught — test passes.
         if not compile_result["success"]:
@@ -66,7 +78,9 @@ class TestCompileVerifyWorkflow:
         """Proof using classical logic passes both compile and verify."""
         from rocq_mcp.server import rocq_compile, rocq_verify
 
-        compile_result = rocq_compile(source=classical_proof, workspace=str(workspace))
+        compile_result = await rocq_compile(
+            source=classical_proof, workspace=str(workspace)
+        )
         assert compile_result["success"] is True
 
         verify_result = await rocq_verify(
@@ -88,7 +102,7 @@ class TestCompileVerifyWorkflow:
         """
         from rocq_mcp.server import rocq_compile, rocq_verify
 
-        compile_result = rocq_compile(
+        compile_result = await rocq_compile(
             source=axiom_spoofing_proof, workspace=str(workspace)
         )
         if not compile_result["success"]:
@@ -108,7 +122,9 @@ class TestCompileVerifyWorkflow:
         """Proof with an Admitted helper: compile passes, verify must reject."""
         from rocq_mcp.server import rocq_compile, rocq_verify
 
-        compile_result = rocq_compile(source=admitted_proof, workspace=str(workspace))
+        compile_result = await rocq_compile(
+            source=admitted_proof, workspace=str(workspace)
+        )
         assert compile_result["success"] is True
         verify_result = await rocq_verify(
             proof=admitted_proof,
@@ -143,7 +159,9 @@ class TestCompileVerifyWorkflow:
             "Theorem add_0_r : forall n : nat, n + 0 = n.\n"
             "Admitted.\n"
         )
-        compile_result = rocq_compile(source=injection_proof, workspace=str(workspace))
+        compile_result = await rocq_compile(
+            source=injection_proof, workspace=str(workspace)
+        )
         assert compile_result["success"] is True
 
         verify_result = await rocq_verify(
@@ -161,7 +179,7 @@ class TestCompileVerifyWorkflow:
         """rocq_compile must reject source containing Redirect."""
         from rocq_mcp.server import rocq_compile
 
-        result = rocq_compile(
+        result = _call_rocq_compile(
             source='Redirect "/tmp/evil" Print nat.\nTheorem t : True. Proof. exact I. Qed.',
             workspace=str(workspace),
         )
@@ -172,7 +190,7 @@ class TestCompileVerifyWorkflow:
         """rocq_compile must reject source containing Load."""
         from rocq_mcp.server import rocq_compile
 
-        result = rocq_compile(
+        result = _call_rocq_compile(
             source='Load "evil".\nTheorem t : True. Proof. exact I. Qed.',
             workspace=str(workspace),
         )
@@ -183,7 +201,7 @@ class TestCompileVerifyWorkflow:
         """rocq_compile must reject source containing Drop."""
         from rocq_mcp.server import rocq_compile
 
-        result = rocq_compile(
+        result = _call_rocq_compile(
             source="Drop.\nTheorem t : True. Proof. exact I. Qed.",
             workspace=str(workspace),
         )
@@ -208,7 +226,7 @@ class TestCompileVerifyWorkflow:
         )
 
         # Now compile source that imports Helper via rocq_compile
-        result = rocq_compile(
+        result = _call_rocq_compile(
             source=(
                 "From TestProj Require Import Helper.\n" "Definition x := my_const.\n"
             ),
@@ -242,7 +260,7 @@ class TestCompileVerifyWorkflow:
             "Admitted.\n"
         )
 
-        compile_result = rocq_compile(source=proof, workspace=str(tmp_path))
+        compile_result = await rocq_compile(source=proof, workspace=str(tmp_path))
         assert compile_result["success"] is True
 
         verify_result = await rocq_verify(
@@ -262,7 +280,7 @@ class TestCompileVerifyWorkflow:
         from rocq_mcp.server import rocq_compile, rocq_verify
 
         before = set(glob_mod.glob(str(workspace / "*")))
-        rocq_compile(source=simple_proof, workspace=str(workspace))
+        await rocq_compile(source=simple_proof, workspace=str(workspace))
         await rocq_verify(
             proof=simple_proof,
             problem_name="add_0_r",
@@ -278,7 +296,7 @@ class TestCompileVerifyWorkflow:
         """Multi-line From...Require Import works end-to-end."""
         from rocq_mcp.server import rocq_compile, rocq_verify
 
-        compile_result = rocq_compile(
+        compile_result = await rocq_compile(
             source=multiline_import_proof, workspace=str(workspace)
         )
         assert compile_result["success"] is True
@@ -635,5 +653,5 @@ class TestMiniF2FSample:
 
         # The problem file likely ends with Admitted, so compilation should
         # succeed (Admitted is accepted by coqc). We just verify no crash.
-        result = rocq_compile(source=source, workspace=str(ws))
+        result = _call_rocq_compile(source=source, workspace=str(ws))
         assert "success" in result

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import COQC_AVAILABLE, PET_AVAILABLE
+from tests.conftest import COQC_AVAILABLE, PET_AVAILABLE, _MockContext
 
 
 def _call_rocq_compile(**kwargs):
@@ -324,13 +324,6 @@ class TestCompileVerifyWorkflow:
 # =========================================================================
 
 
-class _MockContext:
-    """Minimal mock for FastMCP Context to inject lifespan_state."""
-
-    def __init__(self, lifespan_state):
-        self.lifespan_context = lifespan_state
-
-
 @pytest.mark.skipif(
     not (COQC_AVAILABLE and PET_AVAILABLE),
     reason="coqc and pet required for compile error state capture",
@@ -347,7 +340,7 @@ class TestCompileErrorStateWorkflow:
         _invalidate_pet(state)
 
     async def test_compile_includes_error_state(self, lifespan_state, workspace):
-        """rocq_compile should attach a recoverable state at the error position."""
+        """rocq_compile attaches a recoverable state with status ``ok``."""
         from rocq_mcp.server import rocq_compile
 
         source = "Theorem bad : True.\n" "Proof.\n" "  exact 0.\n" "Qed.\n"
@@ -356,6 +349,7 @@ class TestCompileErrorStateWorkflow:
         result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
 
         assert result["success"] is False
+        assert result["state_capture_status"] == "ok"
         assert isinstance(result["state_id"], int)
         assert "|-True" in result["goals"]
         assert result["file"] == "<proof>"
@@ -363,9 +357,11 @@ class TestCompileErrorStateWorkflow:
         # the column is set by coqc and may shift across Rocq versions.
         assert result["theorem"].startswith("@pos(2,")
         assert result["proof_finished"] is False
+        # Hint must be rewritten when capture is actionable.
+        assert f"rocq_check(from_state={result['state_id']})" in result["hint"]
 
     async def test_compile_file_includes_error_state(self, lifespan_state, workspace):
-        """rocq_compile_file should attach a recoverable state at the error position."""
+        """rocq_compile_file attaches a recoverable state with status ``ok``."""
         from rocq_mcp.server import rocq_compile_file
 
         path = workspace / "error_state_test.v"
@@ -379,11 +375,95 @@ class TestCompileErrorStateWorkflow:
         )
 
         assert result["success"] is False
+        assert result["state_capture_status"] == "ok"
         assert isinstance(result["state_id"], int)
         assert "|-True" in result["goals"]
         assert result["file"] == "error_state_test.v"
         assert result["theorem"].startswith("@pos(2,")
         assert result["proof_finished"] is False
+        assert f"rocq_check(from_state={result['state_id']})" in result["hint"]
+
+    async def test_state_id_is_consumable_by_rocq_check(
+        self, lifespan_state, workspace
+    ):
+        """The state_id from a real compile failure is usable by rocq_check."""
+        from rocq_mcp.server import rocq_compile, rocq_check
+
+        source = "Theorem bad : True.\n" "Proof.\n" "  exact 0.\n" "Qed.\n"
+        ctx = _MockContext(lifespan_state)
+
+        compile_result = await rocq_compile(
+            source=source, workspace=str(workspace), ctx=ctx
+        )
+        assert compile_result["success"] is False
+        assert compile_result["state_capture_status"] == "ok"
+        state_id = compile_result["state_id"]
+
+        check_result = await rocq_check(
+            body="exact I.",
+            from_state=state_id,
+            ctx=ctx,
+        )
+        assert check_result["success"] is True
+        assert check_result["proof_finished"] is True
+        # rocq_check should advance to a fresh state after the recovery.
+        assert check_result["state_id"] != state_id
+
+    async def test_outside_proof_status_for_bad_definition(
+        self, lifespan_state, workspace
+    ):
+        """A bad ``Definition`` outside any proof yields a non-actionable status.
+
+        Pet/Rocq may either return cleanly with no open goals
+        (``outside_proof``) or raise (``crashed``); both are non-``"ok"``.
+        Either way, no ``state_id`` should leak and the original
+        ``Use rocq_start(...)`` guidance must be preserved.
+        """
+        from rocq_mcp.server import rocq_compile
+
+        source = "Definition bad : nat := wrong_term.\n"
+        ctx = _MockContext(lifespan_state)
+
+        result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
+
+        assert result["success"] is False
+        assert result["state_capture_status"] in {"outside_proof", "crashed"}
+        assert "state_id" not in result
+        assert "Use rocq_start" in result["hint"]
+        assert "rocq_check(from_state=" not in result["hint"]
+
+    async def test_multi_theorem_second_fails_captures_at_second(
+        self, lifespan_state, workspace
+    ):
+        """First theorem compiles, second fails: capture must point inside the second."""
+        from rocq_mcp.server import rocq_compile
+
+        source = (
+            "Theorem ok : True.\n"
+            "Proof. exact I. Qed.\n"
+            "\n"
+            "Theorem broken : True.\n"
+            "Proof.\n"
+            "  exact 0.\n"
+            "Qed.\n"
+        )
+        ctx = _MockContext(lifespan_state)
+
+        result = await rocq_compile(source=source, workspace=str(workspace), ctx=ctx)
+
+        assert result["success"] is False
+        assert result["state_capture_status"] == "ok"
+        m = re.match(r"@pos\((\d+),(\d+)\)", result["theorem"])
+        assert m, f"theorem should be @pos(line,col), got {result['theorem']!r}"
+        line = int(m.group(1))
+        # The "exact 0." line of the second theorem is line 5 (0-indexed).
+        # Allow some flexibility for coqc reporting variance, but it must land
+        # in the broken theorem's body (line >= 4 = "Theorem broken : True.").
+        assert line >= 4, (
+            f"capture should land inside the failing second theorem; "
+            f"got line={line}"
+        )
+        assert "|-True" in result["goals"]
 
     async def test_compile_with_assumption_includes_goal_context(
         self, lifespan_state, workspace

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -553,10 +553,9 @@ class TestRocqQueryWrapper:
     @pytest.mark.asyncio
     async def test_invalid_workspace_returns_error(self):
         from rocq_mcp.server import rocq_query
-        from unittest.mock import MagicMock
+        from tests.conftest import _MockContext
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {}
+        mock_ctx = _MockContext({})
         result = await rocq_query(
             command="Check nat.",
             workspace="/nonexistent_rocq_workspace_xyz",
@@ -568,7 +567,7 @@ class TestRocqQueryWrapper:
     async def test_params_forwarded(self, monkeypatch, tmp_path):
         """Wrapper should forward all params to run_query."""
         from rocq_mcp.server import rocq_query
-        from unittest.mock import MagicMock
+        from tests.conftest import _MockContext
         import rocq_mcp.server as _server
 
         captured = {}
@@ -580,8 +579,7 @@ class TestRocqQueryWrapper:
         monkeypatch.setattr(_server, "run_query", mock_run_query)
         monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
 
-        mock_ctx = MagicMock()
-        mock_ctx.lifespan_context = {"pet_client": None}
+        mock_ctx = _MockContext({"pet_client": None})
 
         await rocq_query(
             command="Check nat.",


### PR DESCRIPTION
In my experiments with `rocq-mcp`, I have noticed that agents quite often end up in an unproductive loop of "call `rocq_compile` - edit the file - repeat" due to a misunderstanding of the current proof state. Usually, I want that the agent calls `rocq_start` at the respective position after encountering an error, but this has sometimes been tricky, I suspect either because of overconfidence or because the agent has a built-in hesitancy with calling tools for cost reasons.

This PR automates that process: If `rocq_compile` fails and `coq-lsp` is installed then it also returns the output of `rocq_start`.

From some initial tests, it seemed to be helpful (though I didn't try to benchmark the change). **This is a draft PR for now as I have not actually read the code :)** However, I'd like to discuss whether this is actually a feature you're interested in.

Implementation wasn't as straight-forward as I hoped. It's split into two commits:
1. Make `rocq_compile` and `rocq_compile_file` tool calls entirely async to support interacting with `coq-lsp` as part of their implementation.
2. Implement the feature.


