### PR TITLE
Document position-rounding semantics in rocq_start

### DIFF
--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -1211,7 +1211,15 @@ def _build_position_start_result(
     character: int,
     track_staleness: bool = True,
 ) -> dict[str, Any]:
-    """Return the rocq_start-style payload for a position-based state."""
+    """Return the rocq_start-style payload for a position-based state.
+
+    ``line`` / ``character`` are 0-indexed.  Petanque rounds the cursor
+    forward through the sentence it lies in: a cursor on any character
+    of a sentence (first letter through terminating period) yields the
+    state AFTER that sentence; a cursor in the whitespace before a
+    sentence yields the state BEFORE it.  See ``rocq_start`` for the
+    full rule.
+    """
     _server._set_workspace_if_needed(pet, workspace, lifespan_state)
     state = pet.get_state_at_pos(resolved_file, line, character)
 

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -1770,6 +1770,24 @@ async def rocq_start(
        position returned by rocq_compile.
     3. From imports: preamble — set up import context only (for rocq_check)
 
+    **Position semantics (mode 2):** ``line`` and ``character`` are
+    0-indexed.  Petanque resolves the cursor to a sentence boundary by
+    *rounding forward* through the sentence that contains the cursor:
+
+    - Cursor on any character of a sentence — its first letter, any
+      character inside, or its terminating period — yields the state
+      **after** that whole sentence has executed.
+    - Cursor in the whitespace **before** a sentence's first
+      non-whitespace character yields the state **before** that
+      sentence (= after the previous sentence).
+    - Cursor in the whitespace **after** a sentence's terminating
+      period yields the state **after** that sentence.
+
+    So to inspect goals **before** a tactic, point at the whitespace
+    just before its first character.  To inspect goals **after** a
+    tactic, point at any character of the tactic (including its
+    period) or at the whitespace immediately following the period.
+
     **Important:** The interactive session reads the file at start time and
     does not track subsequent edits. If another process or agent modifies the
     file while a session is active, the proof state becomes stale and tactics
@@ -1783,8 +1801,11 @@ async def rocq_start(
             up from *file* looking for ``_RocqProject`` / ``_CoqProject`` /
             ``dune-project``; falls back to the ``ROCQ_WORKSPACE`` env var
             (default: cwd).
-        line: 0-based line number for position-based start.
+        line: 0-based line number for position-based start.  See
+            "Position semantics" above for how the cursor is resolved
+            to a sentence boundary.
         character: 0-based character offset for position-based start.
+            See "Position semantics" above.
         preamble: Import commands for preamble mode (e.g., "Require Import Lia.").
         force_restart: If True, kill the current PET process and clear all
             cached state before starting.  Use when PET is alive but in a

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -193,6 +193,111 @@ class TestStartByPosition:
         )
         assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_position_rounds_forward_through_sentence(
+        self, workspace, lifespan_state
+    ):
+        """Pin the position semantics documented in ``rocq_start``.
+
+        Petanque's ``get_state_at_pos`` rounds the cursor *forward*
+        through the sentence containing it.  This test probes every
+        category of cursor placement against a known file and asserts
+        which sentence has executed:
+
+            Line 0: Theorem foo : forall n : nat, n = n.
+            Line 1: Proof. intros n. reflexivity. Qed.
+                    0123456789012345678901234567890123
+                          ^      ^       ^   ^   ^
+                          space  i.intros .   space-after-.
+                                         period
+
+        Distinguishing signals:
+        - Before ``intros n.``: goal still contains ``forall``.
+        - After  ``intros n.``: goal lacks ``forall`` and an ``n :
+          nat`` hypothesis is in scope.
+        - After  ``reflexivity.``: ``proof_finished`` flips to True.
+
+        Each of these is what the docstring promises will be reachable
+        from the corresponding cursor position; if petanque ever
+        changes the rounding rule, this test will catch it before the
+        docstring goes stale.
+        """
+        from rocq_mcp.interactive import run_start
+
+        vfile = workspace / "pos_semantics.v"
+        vfile.write_text(
+            "Theorem foo : forall n : nat, n = n.\n"
+            "Proof. intros n. reflexivity. Qed.\n"
+        )
+
+        async def probe(character: int) -> dict:
+            return await run_start(
+                file=str(vfile),
+                theorem="",
+                workspace=str(workspace),
+                lifespan_state=lifespan_state,
+                line=1,
+                character=character,
+            )
+
+        # Sentence layout on line 1: "Proof. intros n. reflexivity. Qed."
+        # period positions: 5, 15, 28, 33
+        # whitespace gaps:  6, 16, 29
+
+        # --- BEFORE `intros n.` -------------------------------------------------
+        # char 6 is the space immediately preceding `intros` -- whitespace
+        # before a sentence yields the state BEFORE that sentence.  The
+        # `Proof.` keyword is a no-op here, so the goal is the bare theorem
+        # statement.
+        r6 = await probe(6)
+        assert r6["success"] is True
+        assert r6["proof_finished"] is False
+        assert "forall" in r6["goals"], (
+            "Cursor at whitespace before `intros n.` should yield state BEFORE "
+            f"intros (goal should still contain forall). Got: {r6['goals']!r}"
+        )
+
+        # --- AFTER `intros n.` (three equivalent cursor placements) ------------
+        # Per the docstring, all of these resolve to the SAME state: after
+        # `intros n.` has executed.  Once `intros n.` runs, `n : nat` is in
+        # scope and `forall` is gone from the goal.
+        after_intros_positions = {
+            7: "first letter of `intros`",
+            10: "middle of `intros`",
+            15: "the period terminating `intros n.`",
+            16: "whitespace immediately after the period",
+        }
+        for ch, label in after_intros_positions.items():
+            r = await probe(ch)
+            assert r["success"] is True, f"probe at char {ch} ({label}) failed"
+            assert r["proof_finished"] is False, (
+                f"char {ch} ({label}): proof should still be open "
+                f"(reflexivity not yet run)"
+            )
+            assert "forall" not in r["goals"], (
+                f"char {ch} ({label}): goal should no longer contain forall "
+                f"after `intros n.`. Got: {r['goals']!r}"
+            )
+            assert "n : nat" in r["goals"] or "n: nat" in r["goals"], (
+                f"char {ch} ({label}): expected `n : nat` hypothesis after "
+                f"`intros n.`. Got: {r['goals']!r}"
+            )
+
+        # --- AFTER `reflexivity.` ----------------------------------------------
+        # char 17 is the first letter of `reflexivity` -- rounding forward
+        # through that sentence runs it, which closes the only goal.
+        r17 = await probe(17)
+        assert r17["success"] is True
+        assert r17["proof_finished"] is True, (
+            "Cursor on first letter of `reflexivity` should yield state AFTER "
+            "reflexivity, with proof finished."
+        )
+        # And the period of `reflexivity.` plus the whitespace after it agree.
+        r28 = await probe(28)
+        assert r28["proof_finished"] is True
+        r29 = await probe(29)
+        assert r29["proof_finished"] is True
+
 
 # ---------------------------------------------------------------------------
 # TestStartByPreamble


### PR DESCRIPTION
Document how rocq_start treats positions more clearly: any character inside a tactic (including the period) rounds forward. Add a test that confirms this semantics.