### PR TITLE
Pattern-based diagnostic_hint on compile failures (load-path / Coq-version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ Every failure response carries `{success: False, error: str, reason: str}` so an
 
 When a tool returns `pet_restarted: True`, call `rocq_diag` for memory headroom and recent-error history.
 
+### `diagnostic_hint`: pattern-based hints for common configuration errors
+
+`rocq_compile` and `rocq_compile_file` attach a `diagnostic_hint: str` field to the failure envelope when the coqc error matches a known configuration failure pattern. Currently recognised:
+
+- **Missing load path** — `Cannot find a physical path bound to logical path X.` Indicates a missing `-Q` / `-R` entry in `_CoqProject` (or `_RocqProject`), or a workspace pointing at the wrong directory. The hint names the offending logical path and points at the project file.
+- **Coq version mismatch** — `Compiled library X makes inconsistent assumptions over library Coq.Init.Prelude.` Indicates that pet's coqc is from a different opam switch than the one that produced the workspace's `.vo` files. The hint suggests running `coqc --version` and either installing the matching Coq or rebuilding the dependencies.
+
+`diagnostic_hint` complements the existing `hint` (which is *recovery* advice — use `rocq_start` at the error position). When both are present, `diagnostic_hint` typically tells the agent how to fix the underlying configuration so the proof effort can actually proceed; `hint` tells it how to inspect the failure point in the meantime.
+
 ### Concurrency model
 
 *Background (both audiences):* `rocq-mcp` is **single-tenant per process**.  All agent-facing state — the live `state_id` table, the import cache, the active workspace, and the single `pet` subprocess — is process-global.  Actively-used states are LRU-protected: a `state_id` you keep querying via `from_state` will not be evicted by a peer caller churning through new states (see `ROCQ_MAX_STATES`).  The remaining cross-agent costs are workspace-swap latency, pet RAM growth from accumulated Fleche cache, and the rare case of a peer calling `force_restart=True` (which kills pet under everyone).

--- a/src/rocq_mcp/compile.py
+++ b/src/rocq_mcp/compile.py
@@ -177,6 +177,73 @@ _COQC_POS_RE = re.compile(
 )
 
 
+# Pattern → diagnostic-hint table for common configuration errors.
+# Each entry pairs a compiled regex against an error string with a
+# template.  Templates may reference named groups from the match
+# (``{name}``) to incorporate the offending identifier into the hint.
+#
+# Why this exists: the bare coqc error tells the agent what failed
+# but not *why* — and the why is almost always a workspace/load-path
+# misconfiguration, not a proof bug.  Hints here steer the agent
+# toward fixing config instead of grinding tactics.
+_MISSING_LOAD_PATH_RE = re.compile(
+    r"Cannot find a physical path bound to logical path\s+(?P<name>[\w.]+)",
+    re.IGNORECASE,
+)
+_VERSION_MISMATCH_RE = re.compile(
+    r"makes inconsistent assumptions over library\s+(?P<library>[\w.]+)",
+    re.IGNORECASE,
+)
+
+
+def _diagnostic_hint_for_error(error: str | None) -> str | None:
+    """Return an actionable diagnostic hint for *error*, or None.
+
+    Pattern-matches the coqc error text against known configuration
+    failure modes.  Returns a one-line hint mentioning the
+    misconfigured surface (load path, Coq version) and the offending
+    identifier from the error, when extractable.
+
+    Recovery-style hints (use rocq_start at the position, etc.) are
+    set elsewhere and remain in the response.  This function returns
+    a *separate* string that callers can attach as
+    ``diagnostic_hint`` so the agent can choose to read both.
+
+    Returns None when:
+    - *error* is empty or None
+    - no pattern matched (likely a proof-level error — the existing
+      recovery hint is the right guidance)
+    """
+    if not error:
+        return None
+    m = _MISSING_LOAD_PATH_RE.search(error)
+    if m is not None:
+        # Strip the trailing sentence period that the regex's [\w.]+
+        # greedily captures — the user expects a clean logical name.
+        name = m.group("name").rstrip(".")
+        return (
+            f"Load-path mismatch: no -Q / -R mapping for logical "
+            f"path '{name}'. Check the workspace's _CoqProject "
+            f"(or _RocqProject) for a line like '-Q <dir> {name}' "
+            f"and verify <dir> exists and contains compiled .vo "
+            f"files. If the directory lives outside the workspace, "
+            f"see the path-containment rules in README.md."
+        )
+    m = _VERSION_MISMATCH_RE.search(error)
+    if m is not None:
+        library = m.group("library").rstrip(".")
+        return (
+            f"Probable Coq version mismatch: the workspace's .vo "
+            f"files were compiled against a different Coq version "
+            f"than the coqc currently in PATH (offending library: "
+            f"'{library}'). Run `coqc --version` and compare with "
+            f"the version that produced your dependencies, then "
+            f"either install the matching Coq via opam or rebuild "
+            f"the .vo files with the current coqc."
+        )
+    return None
+
+
 def _parse_coqc_error_positions(
     stderr: str,
     *,
@@ -435,6 +502,13 @@ def _build_compile_result(
             "Use rocq_check for faster iteration, "
             "or rocq_step_multi to explore alternative tactics."
         )
+    # Attach a pattern-based diagnostic_hint when the error looks like
+    # a recognised configuration failure (load path missing, Coq
+    # version mismatch).  Recovery hints alone don't help the agent
+    # *fix the cause* — diagnostic_hint does.
+    diagnostic_hint = _diagnostic_hint_for_error(error_text)
+    if diagnostic_hint:
+        result_dict["diagnostic_hint"] = diagnostic_hint
     return result_dict
 
 

--- a/tests/test_diagnostic_hints.py
+++ b/tests/test_diagnostic_hints.py
@@ -1,0 +1,120 @@
+"""Tests for diagnostic-pattern hints attached to compile errors.
+
+When ``rocq_compile_file`` or ``rocq_compile`` fails with a coqc
+error, the response carries an ``error`` string and (usually) an
+``error_positions`` list.  The existing ``hint`` field tells the
+agent how to *recover* (use ``rocq_start`` at the position, etc.)
+but doesn't help diagnose the *cause* of common configuration
+errors.
+
+This module exercises a pattern-based diagnostic hint: a
+``diagnostic_hint`` field that recognises common Coq error
+shapes and tells the agent what's actually wrong, so it can fix
+the configuration instead of grinding on the proof.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_diagnostic_hint_for_missing_load_path():
+    """``Cannot find a physical path bound to logical path X`` is a
+    load-path configuration error, not a proof bug.  The agent
+    should be told to check ``_CoqProject`` / ``-Q``, not to retry
+    proof tactics.
+    """
+    from rocq_mcp.compile import _diagnostic_hint_for_error  # noqa: PLC0415
+
+    error = (
+        'File "Sandbox.v", line 33, characters 15-44:\n'
+        "Error: Cannot find a physical path bound to logical path\n"
+        "RocqOfSolidity.RocqOfSolidity."
+    )
+    hint = _diagnostic_hint_for_error(error)
+    assert hint is not None
+    lower = hint.lower()
+    # Hint should reference _CoqProject / -Q / load path config.
+    assert any(
+        clue in lower
+        for clue in ("_coqproject", "_rocqproject", "-q", "load path", "library")
+    )
+    # And mention the missing logical name.
+    assert "rocqofsolidity" in lower
+
+
+def test_diagnostic_hint_for_coq_version_mismatch():
+    """``makes inconsistent assumptions over library Coq.Init.Prelude``
+    is the canonical signature of a Coq version mismatch: pet's coqc
+    is from a different opam switch than the one that produced the
+    workspace ``.vo`` files.  The hint should call this out by name.
+    """
+    from rocq_mcp.compile import _diagnostic_hint_for_error  # noqa: PLC0415
+
+    error = (
+        'File "./Foo.v", line 1, characters 0-30:\n'
+        "Error:\n"
+        "Compiled library RocqOfSolidity.RocqOfSolidity (in file "
+        "/path/to/dep.vo) makes inconsistent assumptions over library "
+        "Coq.Init.Prelude"
+    )
+    hint = _diagnostic_hint_for_error(error)
+    assert hint is not None
+    lower = hint.lower()
+    assert "version" in lower or "switch" in lower or "rebuild" in lower
+    assert "inconsistent" in lower or ".vo" in lower or "prelude" in lower
+
+
+def test_diagnostic_hint_for_unrelated_error_returns_none():
+    """Tactic-level errors are out of scope — ``Tactic failure`` is a
+    proof issue and the existing recovery hint already covers it.
+    """
+    from rocq_mcp.compile import _diagnostic_hint_for_error  # noqa: PLC0415
+
+    error = (
+        'File "Foo.v", line 5, characters 0-10:\n'
+        "Error: Tactic failure: no progress made."
+    )
+    hint = _diagnostic_hint_for_error(error)
+    assert hint is None, (
+        f"Expected no diagnostic_hint for a tactic failure (the existing "
+        f"recovery hint already covers it). Got: {hint!r}"
+    )
+
+
+def test_diagnostic_hint_for_empty_error_returns_none():
+    """Empty / None input must return None — never raise."""
+    from rocq_mcp.compile import _diagnostic_hint_for_error  # noqa: PLC0415
+
+    assert _diagnostic_hint_for_error("") is None
+    assert _diagnostic_hint_for_error(None) is None  # type: ignore[arg-type]
+
+
+class TestDiagnosticHintWiredIntoCompileFile:
+    """Integration: ``rocq_compile_file`` should attach
+    ``diagnostic_hint`` to the failure envelope when the coqc error
+    matches a known configuration-failure pattern.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_load_path_surfaces_diagnostic_hint(self, tmp_path):
+        from rocq_mcp.server import rocq_compile_file
+
+        broken = tmp_path / "Broken.v"
+        broken.write_text("Require Import NotAProject.Lib.\n")
+
+        result = await rocq_compile_file(
+            file=str(broken.name),
+            workspace=str(tmp_path),
+        )
+        assert result["success"] is False
+        assert result["reason"] == "compile_error"
+        # The new field must be present and mention either the
+        # logical name or load-path / _CoqProject.
+        diag = result.get("diagnostic_hint") or ""
+        assert diag, f"Expected diagnostic_hint, got: {result!r}"
+        lower = diag.lower()
+        assert any(
+            clue in lower
+            for clue in ("notaproject", "load path", "_coqproject", "-q")
+        )


### PR DESCRIPTION
## Summary

Two common coqc errors in agent-driven workflows look like proof bugs but are workspace configuration issues:

1. `Cannot find a physical path bound to logical path X.` — missing `-Q` / `-R` mapping in `_CoqProject` (or workspace pointed at the wrong directory).
2. `Compiled library X makes inconsistent assumptions over library Coq.Init.Prelude.` — Coq version mismatch between pet's coqc and the workspace's `.vo` files.

Today's response includes a `hint` field that tells the agent how to *recover* (\`rocq_start\` at the error position). That's fine when the failure is a proof bug, but useless when the failure is a config bug — the agent then iterates on tactics that can never succeed.

This PR adds a complementary `diagnostic_hint: str` field that pattern-matches the coqc error and emits an actionable one-liner naming the offending logical path or library and the setting to fix. The existing `hint` is unchanged.

## Real-world background

In a recent debugging session I spent hours staring at \`Theorem_not_found\` errors caused by a Coq version mismatch (pet from one opam switch, `.vo` files from another). The actual coqc error was clear (\`inconsistent assumptions over library Coq.Init.Prelude\`) but the recovery hint didn't acknowledge it as a version issue. With this PR, the agent gets a one-liner naming the cause and the fix.

## Tests

5 new pytest cases in `tests/test_diagnostic_hints.py`:

- Two pattern-match tests covering the recognised error shapes.
- One negative test (tactic-failure errors return `None` — the existing recovery hint is correct for proof bugs).
- One edge case (`None` / empty input returns `None` without raising).
- One end-to-end integration test through `rocq_compile_file`.

`uv run pytest tests/test_diagnostic_hints.py tests/test_compile.py tests/test_compile_file.py` — 60 pass.

## Notes

The pattern table is intentionally small and conservative: I added only patterns where I have high confidence the diagnosis is correct. Adding more is a matter of pasting new `re.compile(...)` entries and an `if m := ...` block — happy to extend if there are other patterns you'd want recognised (e.g. `Unbound section variable`, dune-coq stanza mismatches).