### PR TITLE
feat: per-call timeout on rocq_assumptions, rocq_toc, rocq_notations,…

### DIFF
--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -635,6 +635,8 @@ async def run_assumptions(
     file: str,
     workspace: str,
     lifespan_state: dict[str, Any],
+    *,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
     """Core implementation of rocq_assumptions (testable without FastMCP Context).
 
@@ -686,6 +688,7 @@ async def run_assumptions(
         workspace=workspace,
         lifespan_state=lifespan_state,
         file=file,
+        timeout=int(timeout) if timeout is not None and timeout > 0 else None,
     )
     if not query_result.get("success"):
         # Best-effort enrichment: attach the file's symbol list so the
@@ -1084,6 +1087,8 @@ async def run_toc(
     file: str,
     workspace: str,
     lifespan_state: dict[str, Any],
+    *,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
     """Core implementation of rocq_toc (testable without FastMCP Context)."""
     # Path traversal + existence check (before entering thread)
@@ -1114,6 +1119,7 @@ async def run_toc(
         _do_toc,
         lifespan_state,
         "rocq_toc",
+        timeout=timeout,
     )
 
 
@@ -1127,6 +1133,8 @@ async def run_notations(
     preamble: str,
     workspace: str,
     lifespan_state: dict[str, Any],
+    *,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
     """Core implementation of rocq_notations (testable without FastMCP Context)."""
     forbidden = _check_forbidden_commands(statement)
@@ -1196,6 +1204,7 @@ async def run_notations(
         lifespan_state,
         "rocq_notations",
         on_timeout=_on_timeout,
+        timeout=timeout,
     )
 
 

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -1563,6 +1563,7 @@ async def rocq_assumptions(
     name: str,
     file: str,
     workspace: str = "",
+    timeout: int = 0,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """List the axioms a theorem depends on.
@@ -1585,6 +1586,15 @@ async def rocq_assumptions(
             up from *file* looking for ``_RocqProject`` / ``_CoqProject`` /
             ``dune-project``; falls back to the ``ROCQ_WORKSPACE`` env var
             (default: cwd).
+        timeout: Per-call timeout in seconds for the underlying
+            ``Print Assumptions`` query (which loads the file's full
+            import chain).  Default 0 uses ``ROCQ_PET_TIMEOUT`` (env
+            var, default 30).  Raise this for files with heavy import
+            chains.  Clamped to ``ROCQ_QUERY_TIMEOUT_CAP`` (default
+            300s) so a stray large value cannot park the pet lock
+            indefinitely; when clamping fires the response includes
+            ``clamped_timeout: <cap>`` so the caller can diagnose
+            unexpected timeouts.
 
     Returns (key fields):
         success:     bool.
@@ -1609,6 +1619,13 @@ async def rocq_assumptions(
     On ``pet_restarted: True``, call ``rocq_diag`` for memory headroom and
     recent error history.
     """
+    effective_timeout: float | None
+    if timeout and timeout > 0:
+        effective_timeout = float(min(timeout, ROCQ_QUERY_TIMEOUT_CAP))
+    else:
+        effective_timeout = None
+    clamped = effective_timeout is not None and timeout > ROCQ_QUERY_TIMEOUT_CAP
+
     workspace = workspace or _find_project_root_from_file(file) or ROCQ_WORKSPACE
 
     err = _validate_workspace(workspace)
@@ -1627,12 +1644,16 @@ async def rocq_assumptions(
             "error": "Internal error: no MCP context.",
         }
 
-    return await run_assumptions(
+    result = await run_assumptions(
         name=name,
         file=file,
         workspace=workspace,
         lifespan_state=ctx.lifespan_context,
+        timeout=effective_timeout,
     )
+    if clamped:
+        result["clamped_timeout"] = ROCQ_QUERY_TIMEOUT_CAP
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1644,6 +1665,7 @@ async def rocq_assumptions(
 async def rocq_toc(
     file: str,
     workspace: str = "",
+    timeout: int = 0,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """Get the structure of a Rocq file: all definitions, lemmas, theorems, and sections.
@@ -1660,10 +1682,25 @@ async def rocq_toc(
             up from *file* looking for ``_RocqProject`` / ``_CoqProject`` /
             ``dune-project``; falls back to the ``ROCQ_WORKSPACE`` env var
             (default: cwd).
+        timeout: Per-call timeout in seconds for computing the table of
+            contents (which loads the file's full import chain).  Default
+            0 uses ``ROCQ_PET_TIMEOUT`` (env var, default 30).  Raise this
+            for files with heavy import chains.  Clamped to
+            ``ROCQ_QUERY_TIMEOUT_CAP`` (default 300s) so a stray large
+            value cannot park the pet lock indefinitely; when clamping
+            fires the response includes ``clamped_timeout: <cap>`` so the
+            caller can diagnose unexpected timeouts.
 
     On ``pet_restarted: True``, call ``rocq_diag`` for memory headroom and
     recent error history.
     """
+    effective_timeout: float | None
+    if timeout and timeout > 0:
+        effective_timeout = float(min(timeout, ROCQ_QUERY_TIMEOUT_CAP))
+    else:
+        effective_timeout = None
+    clamped = effective_timeout is not None and timeout > ROCQ_QUERY_TIMEOUT_CAP
+
     workspace = workspace or _find_project_root_from_file(file) or ROCQ_WORKSPACE
 
     err = _validate_workspace(workspace)
@@ -1679,11 +1716,15 @@ async def rocq_toc(
             "error": "Internal error: no MCP context.",
         }
 
-    return await run_toc(
+    result = await run_toc(
         file=file,
         workspace=workspace,
         lifespan_state=ctx.lifespan_context,
+        timeout=effective_timeout,
     )
+    if clamped:
+        result["clamped_timeout"] = ROCQ_QUERY_TIMEOUT_CAP
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1696,6 +1737,7 @@ async def rocq_notations(
     statement: str,
     preamble: str = "",
     workspace: str = "",
+    timeout: int = 0,
     ctx: Context = None,
 ) -> dict[str, Any]:
     """List all notations in a Rocq statement and how they resolve.
@@ -1713,10 +1755,25 @@ async def rocq_notations(
         statement: The proposition/type to analyze.
         preamble: Import lines for context (e.g., "Require Import QArith.").
         workspace: Workspace directory (default: ROCQ_WORKSPACE env var).
+        timeout: Per-call timeout in seconds for the dummy-lemma pet
+            session used to resolve notations (which loads the preamble's
+            full import chain).  Default 0 uses ``ROCQ_PET_TIMEOUT`` (env
+            var, default 30).  Raise this for preambles with heavy import
+            chains.  Clamped to ``ROCQ_QUERY_TIMEOUT_CAP`` (default 300s)
+            so a stray large value cannot park the pet lock indefinitely;
+            when clamping fires the response includes ``clamped_timeout:
+            <cap>`` so the caller can diagnose unexpected timeouts.
 
     On ``pet_restarted: True``, call ``rocq_diag`` for memory headroom and
     recent error history.
     """
+    effective_timeout: float | None
+    if timeout and timeout > 0:
+        effective_timeout = float(min(timeout, ROCQ_QUERY_TIMEOUT_CAP))
+    else:
+        effective_timeout = None
+    clamped = effective_timeout is not None and timeout > ROCQ_QUERY_TIMEOUT_CAP
+
     workspace = workspace or ROCQ_WORKSPACE
 
     err = _validate_workspace(workspace)
@@ -1732,12 +1789,16 @@ async def rocq_notations(
             "error": "Internal error: no MCP context.",
         }
 
-    return await run_notations(
+    result = await run_notations(
         statement=statement,
         preamble=preamble,
         workspace=workspace,
         lifespan_state=ctx.lifespan_context,
+        timeout=effective_timeout,
     )
+    if clamped:
+        result["clamped_timeout"] = ROCQ_QUERY_TIMEOUT_CAP
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_assumptions.py
+++ b/tests/test_assumptions.py
@@ -1161,3 +1161,139 @@ class TestCollectTocNames:
         toc = [("x", [_e("x", 2)])]
         names = _collect_toc_names(toc, source=source)
         assert names == ["Real.x"]
+
+
+# ---------------------------------------------------------------------------
+# TestAssumptionsTimeoutForwarding: per-call timeout reaches run_query
+# ---------------------------------------------------------------------------
+
+
+class TestAssumptionsTimeoutForwarding:
+    """Per-call ``timeout`` is plumbed from run_assumptions to run_query.
+
+    Mock-based test that doesn't require pet so it runs in CI without
+    coq-lsp. Verifies the contract that callers can override the
+    session-wide ROCQ_PET_TIMEOUT on a per-call basis.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_assumptions_forwards_timeout(self, monkeypatch, tmp_path):
+        """run_assumptions(timeout=X) forwards X to run_query."""
+        import rocq_mcp.interactive as _int
+
+        vfile = tmp_path / "t.v"
+        vfile.write_text("Theorem t : True. Proof. exact I. Qed.\n")
+        captured: dict = {}
+
+        async def fake_run_query(**kw):
+            captured.update(kw)
+            return {"success": True, "output": "Closed under the global context"}
+
+        monkeypatch.setattr(_int, "run_query", fake_run_query)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_assumptions(
+            name="t",
+            file=str(vfile),
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+            timeout=120.0,
+        )
+        assert captured["timeout"] == 120
+
+    @pytest.mark.asyncio
+    async def test_run_assumptions_default_timeout_is_none(self, monkeypatch, tmp_path):
+        """Without explicit timeout, run_assumptions forwards None."""
+        import rocq_mcp.interactive as _int
+
+        vfile = tmp_path / "t.v"
+        vfile.write_text("Theorem t : True. Proof. exact I. Qed.\n")
+        captured: dict = {}
+
+        async def fake_run_query(**kw):
+            captured.update(kw)
+            return {"success": True, "output": "Closed under the global context"}
+
+        monkeypatch.setattr(_int, "run_query", fake_run_query)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_assumptions(
+            name="t",
+            file=str(vfile),
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+        )
+        assert captured.get("timeout") is None
+
+
+class TestAssumptionsTimeoutClamp:
+    """rocq_assumptions wrapper clamps per-call timeout to ROCQ_QUERY_TIMEOUT_CAP.
+
+    The clamp + ``clamped_timeout`` echo lives in the ``@mcp.tool`` wrapper,
+    not in ``run_assumptions``; an uncapped value would let one call park the
+    shared pet lock for the full duration.  Mirrors the ``rocq_query`` /
+    ``rocq_start`` contract.
+    """
+
+    @staticmethod
+    def _patch(monkeypatch):
+        import rocq_mcp.server as _server
+
+        captured: dict = {}
+
+        async def mock_run_assumptions(**kwargs):
+            captured.update(kwargs)
+            return {"success": True, "assumptions": []}
+
+        monkeypatch.setattr(_server, "run_assumptions", mock_run_assumptions)
+        monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_default_no_clamp(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_assumptions(
+            name="t",
+            file="t.v",
+            workspace=str(tmp_path),
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] is None
+        assert "clamped_timeout" not in result
+
+    @pytest.mark.asyncio
+    async def test_above_cap_clamped_with_signal(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        monkeypatch.setattr(_server, "ROCQ_QUERY_TIMEOUT_CAP", 100)
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_assumptions(
+            name="t",
+            file="t.v",
+            workspace=str(tmp_path),
+            timeout=9999,
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] == 100.0
+        assert result["clamped_timeout"] == 100
+
+    @pytest.mark.asyncio
+    async def test_below_cap_forwarded(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        monkeypatch.setattr(_server, "ROCQ_QUERY_TIMEOUT_CAP", 300)
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_assumptions(
+            name="t",
+            file="t.v",
+            workspace=str(tmp_path),
+            timeout=120,
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] == 120.0
+        assert "clamped_timeout" not in result

--- a/tests/test_notations.py
+++ b/tests/test_notations.py
@@ -313,3 +313,131 @@ class TestRunNotationsReal:
         assert "_ + _" in lines[1]
         assert "_ = _" in lines[2]
         assert "_ * _" in lines[3]
+
+
+# ---------------------------------------------------------------------------
+# TestNotationsTimeoutForwarding: per-call timeout reaches _run_with_pet
+# ---------------------------------------------------------------------------
+
+
+class TestNotationsTimeoutForwarding:
+    """Per-call ``timeout`` is plumbed from run_notations to _run_with_pet."""
+
+    @pytest.mark.asyncio
+    async def test_run_notations_forwards_timeout(self, monkeypatch, tmp_path):
+        """run_notations(timeout=X) forwards X to _run_with_pet."""
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import run_notations
+
+        captured: dict = {}
+
+        async def fake_run_with_pet(fn, lifespan_state, tool, **kw):
+            captured.update(kw)
+            captured["tool"] = tool
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(srv, "_run_with_pet", fake_run_with_pet)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_notations(
+            statement="forall n : nat, n = n",
+            preamble="",
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+            timeout=120.0,
+        )
+        assert captured["tool"] == "rocq_notations"
+        assert captured["timeout"] == 120.0
+
+    @pytest.mark.asyncio
+    async def test_run_notations_default_timeout_is_none(self, monkeypatch, tmp_path):
+        """Without explicit timeout, run_notations forwards None."""
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import run_notations
+
+        captured: dict = {}
+
+        async def fake_run_with_pet(fn, lifespan_state, tool, **kw):
+            captured.update(kw)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(srv, "_run_with_pet", fake_run_with_pet)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_notations(
+            statement="forall n : nat, n = n",
+            preamble="",
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+        )
+        assert captured.get("timeout") is None
+
+
+class TestNotationsTimeoutClamp:
+    """rocq_notations wrapper clamps per-call timeout to ROCQ_QUERY_TIMEOUT_CAP.
+
+    The clamp + ``clamped_timeout`` echo lives in the ``@mcp.tool`` wrapper,
+    not in ``run_notations``; an uncapped value would let one call park the
+    shared pet lock for the full duration.  Mirrors the ``rocq_query`` /
+    ``rocq_start`` contract.
+    """
+
+    @staticmethod
+    def _patch(monkeypatch):
+        import rocq_mcp.server as _server
+
+        captured: dict = {}
+
+        async def mock_run_notations(**kwargs):
+            captured.update(kwargs)
+            return {"success": True, "notations": []}
+
+        monkeypatch.setattr(_server, "run_notations", mock_run_notations)
+        monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_default_no_clamp(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_notations(
+            statement="forall n : nat, n = n",
+            workspace=str(tmp_path),
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] is None
+        assert "clamped_timeout" not in result
+
+    @pytest.mark.asyncio
+    async def test_above_cap_clamped_with_signal(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        monkeypatch.setattr(_server, "ROCQ_QUERY_TIMEOUT_CAP", 100)
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_notations(
+            statement="forall n : nat, n = n",
+            workspace=str(tmp_path),
+            timeout=9999,
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] == 100.0
+        assert result["clamped_timeout"] == 100
+
+    @pytest.mark.asyncio
+    async def test_below_cap_forwarded(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        monkeypatch.setattr(_server, "ROCQ_QUERY_TIMEOUT_CAP", 300)
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_notations(
+            statement="forall n : nat, n = n",
+            workspace=str(tmp_path),
+            timeout=120,
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] == 120.0
+        assert "clamped_timeout" not in result

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1231,3 +1231,76 @@ class TestLspSeverityWire:
         # The deprecation warning must be filtered out.
         assert "deprecat" not in without_warn["output"].lower()
         assert "from stdlib" not in without_warn["output"].lower()
+
+
+# ---------------------------------------------------------------------------
+# TestQueryFileTimeoutForwarding: per-call timeout reaches _run_with_pet
+# ---------------------------------------------------------------------------
+
+import pytest as _pytest_tf
+
+
+class TestQueryFileTimeoutForwarding:
+    """Per-call ``timeout`` in file-mode reaches _run_with_pet.
+
+    Mock-based test that doesn't require pet. Verifies that the
+    ``timeout`` parameter on rocq_query (file mode) is propagated
+    through run_query into the per-call _run_with_pet keyword arg.
+    """
+
+    @_pytest_tf.mark.asyncio
+    async def test_run_query_file_mode_forwards_timeout(self, monkeypatch, tmp_path):
+        """run_query(file=..., timeout=X) forwards X to _run_with_pet."""
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import run_query
+
+        vfile = tmp_path / "t.v"
+        vfile.write_text("Theorem t : True. Proof. exact I. Qed.\n")
+        captured: dict = {}
+
+        async def fake_run_with_pet(fn, lifespan_state, tool, **kw):
+            captured.update(kw)
+            captured["tool"] = tool
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(srv, "_run_with_pet", fake_run_with_pet)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_query(
+            command="Check t.",
+            preamble="",
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+            file=str(vfile),
+            timeout=120,
+        )
+        assert captured["tool"] == "rocq_query"
+        assert captured["timeout"] == 120
+
+    @_pytest_tf.mark.asyncio
+    async def test_run_query_file_mode_default_timeout_is_none(
+        self, monkeypatch, tmp_path
+    ):
+        """Without explicit timeout, run_query forwards None."""
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import run_query
+
+        vfile = tmp_path / "t.v"
+        vfile.write_text("Theorem t : True. Proof. exact I. Qed.\n")
+        captured: dict = {}
+
+        async def fake_run_with_pet(fn, lifespan_state, tool, **kw):
+            captured.update(kw)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(srv, "_run_with_pet", fake_run_with_pet)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_query(
+            command="Check t.",
+            preamble="",
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+            file=str(vfile),
+        )
+        assert captured.get("timeout") is None

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -188,3 +188,133 @@ class TestTocPathTraversal:
         )
         assert result["success"] is False
         assert "workspace" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# TestTocTimeoutForwarding: per-call timeout reaches _run_with_pet
+# ---------------------------------------------------------------------------
+
+
+class TestTocTimeoutForwarding:
+    """Per-call ``timeout`` is plumbed from run_toc to _run_with_pet."""
+
+    @pytest.mark.asyncio
+    async def test_run_toc_forwards_timeout(self, monkeypatch, tmp_path):
+        """run_toc(timeout=X) forwards X to _run_with_pet."""
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import run_toc
+
+        vfile = tmp_path / "t.v"
+        vfile.write_text("Theorem t : True. Proof. exact I. Qed.\n")
+        captured: dict = {}
+
+        async def fake_run_with_pet(fn, lifespan_state, tool, **kw):
+            captured.update(kw)
+            captured["tool"] = tool
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(srv, "_run_with_pet", fake_run_with_pet)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_toc(
+            file=str(vfile),
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+            timeout=120.0,
+        )
+        assert captured["tool"] == "rocq_toc"
+        assert captured["timeout"] == 120.0
+
+    @pytest.mark.asyncio
+    async def test_run_toc_default_timeout_is_none(self, monkeypatch, tmp_path):
+        """Without explicit timeout, run_toc forwards None (server default)."""
+        import rocq_mcp.server as srv
+        from rocq_mcp.interactive import run_toc
+
+        vfile = tmp_path / "t.v"
+        vfile.write_text("Theorem t : True. Proof. exact I. Qed.\n")
+        captured: dict = {}
+
+        async def fake_run_with_pet(fn, lifespan_state, tool, **kw):
+            captured.update(kw)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(srv, "_run_with_pet", fake_run_with_pet)
+
+        lifespan_state = {"pet_timeout": 30.0}
+        await run_toc(
+            file=str(vfile),
+            workspace=str(tmp_path),
+            lifespan_state=lifespan_state,
+        )
+        assert captured.get("timeout") is None
+
+
+class TestTocTimeoutClamp:
+    """rocq_toc wrapper clamps per-call timeout to ROCQ_QUERY_TIMEOUT_CAP.
+
+    The clamp + ``clamped_timeout`` echo lives in the ``@mcp.tool`` wrapper,
+    not in ``run_toc``; an uncapped value would let one call park the shared
+    pet lock for the full duration.  Mirrors the ``rocq_query`` /
+    ``rocq_start`` contract.
+    """
+
+    @staticmethod
+    def _patch(monkeypatch):
+        import rocq_mcp.server as _server
+
+        captured: dict = {}
+
+        async def mock_run_toc(**kwargs):
+            captured.update(kwargs)
+            return {"success": True, "toc": []}
+
+        monkeypatch.setattr(_server, "run_toc", mock_run_toc)
+        monkeypatch.setattr(_server, "_validate_workspace", lambda ws: None)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_default_no_clamp(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_toc(
+            file="t.v",
+            workspace=str(tmp_path),
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] is None
+        assert "clamped_timeout" not in result
+
+    @pytest.mark.asyncio
+    async def test_above_cap_clamped_with_signal(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        monkeypatch.setattr(_server, "ROCQ_QUERY_TIMEOUT_CAP", 100)
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_toc(
+            file="t.v",
+            workspace=str(tmp_path),
+            timeout=9999,
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] == 100.0
+        assert result["clamped_timeout"] == 100
+
+    @pytest.mark.asyncio
+    async def test_below_cap_forwarded(self, monkeypatch, tmp_path):
+        import rocq_mcp.server as _server
+        from tests.conftest import _MockContext
+
+        monkeypatch.setattr(_server, "ROCQ_QUERY_TIMEOUT_CAP", 300)
+        captured = self._patch(monkeypatch)
+        result = await _server.rocq_toc(
+            file="t.v",
+            workspace=str(tmp_path),
+            timeout=120,
+            ctx=_MockContext({"pet_timeout": 30.0}),
+        )
+        assert captured["timeout"] == 120.0
+        assert "clamped_timeout" not in result


### PR DESCRIPTION
Extends the per-call `timeout` pattern (merged in PR #20 for rocq_start / rocq_step_multi) to the remaining pet-loading tools.