### PR TITLE
Report focus_depth on proof-state responses

### DIFF
--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -133,8 +133,7 @@ def _focus_depth(complete: Any) -> int | None:
     """
     if complete is None:
         return None
-    stack = getattr(complete, "stack", None) or []
-    return len(stack)
+    return len(complete.stack)
 
 
 def _try_get_goals_with_depth(pet: Any, state: Any) -> tuple[str | None, int | None]:
@@ -144,15 +143,16 @@ def _try_get_goals_with_depth(pet: Any, state: Any) -> tuple[str | None, int | N
     """
     try:
         complete = pet.complete_goals(state)
+        goals_list = complete.goals if complete else []
+        return _format_goals(goals_list) or None, _focus_depth(complete)
     except Exception:
         return None, None
-    goals_list = complete.goals if complete else []
-    return _format_goals(goals_list) or None, _focus_depth(complete)
 
 
 def _try_get_goals(pet: Any, state: Any) -> str | None:
     """Best-effort goal retrieval.  Returns formatted text or None."""
-    return _try_get_goals_with_depth(pet, state)[0]
+    text, _ = _try_get_goals_with_depth(pet, state)
+    return text
 
 
 # ---------------------------------------------------------------------------

--- a/src/rocq_mcp/interactive.py
+++ b/src/rocq_mcp/interactive.py
@@ -121,15 +121,38 @@ def _format_goals(goals_list: list[Any]) -> str:
     return result
 
 
-def _try_get_goals(pet: Any, state: Any) -> str | None:
-    """Best-effort goal retrieval.  Returns formatted text or None."""
+def _focus_depth(complete: Any) -> int | None:
+    """How many ``{...}`` / bullet focus frames are open above the goal.
+
+    Each suspended focus level is one entry in a ``complete_goals``
+    result's proof ``stack``, so ``len(stack)`` is the current nesting
+    depth: ``0`` in a flat, unfocused context, ``1`` just inside a ``{``
+    or a bullet, and so on.  Returns ``None`` only when *complete* itself
+    is ``None`` (no goal information — e.g. a non-proof state or an
+    upstream pet error).
+    """
+    if complete is None:
+        return None
+    stack = getattr(complete, "stack", None) or []
+    return len(stack)
+
+
+def _try_get_goals_with_depth(pet: Any, state: Any) -> tuple[str | None, int | None]:
+    """Best-effort ``(goals_text, focus_depth)`` from one ``complete_goals`` call.
+
+    Both elements are ``None`` if the call fails.
+    """
     try:
         complete = pet.complete_goals(state)
-        goals_list = complete.goals if complete else []
-        text = _format_goals(goals_list)
-        return text or None
     except Exception:
-        return None
+        return None, None
+    goals_list = complete.goals if complete else []
+    return _format_goals(goals_list) or None, _focus_depth(complete)
+
+
+def _try_get_goals(pet: Any, state: Any) -> str | None:
+    """Best-effort goal retrieval.  Returns formatted text or None."""
+    return _try_get_goals_with_depth(pet, state)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -1333,15 +1356,18 @@ def _build_position_start_result(
         file_mtime=file_mtime,
         resolved_file=tracked_file,
     )
-    goals = _try_get_goals(pet, state) or ""
-    return {
+    goals, focus_depth = _try_get_goals_with_depth(pet, state)
+    result: dict[str, Any] = {
         "success": True,
         "state_id": state_id,
-        "goals": goals,
+        "goals": goals or "",
         "file": file,
         "theorem": theorem,
         "proof_finished": getattr(state, "proof_finished", False),
     }
+    if focus_depth is not None:
+        result["focus_depth"] = focus_depth
+    return result
 
 
 def _build_theorem_start_result(
@@ -1399,15 +1425,18 @@ def _build_theorem_start_result(
         file_mtime=file_mtime,
         resolved_file=resolved_file,
     )
-    goals = _try_get_goals(pet, state) or ""
-    return {
+    goals, focus_depth = _try_get_goals_with_depth(pet, state)
+    result: dict[str, Any] = {
         "success": True,
         "state_id": state_id,
-        "goals": goals,
+        "goals": goals or "",
         "file": file,
         "theorem": theorem,
         "proof_finished": getattr(state, "proof_finished", False),
     }
+    if focus_depth is not None:
+        result["focus_depth"] = focus_depth
+    return result
 
 
 def _build_preamble_start_result(
@@ -1741,6 +1770,9 @@ def _build_check_success_dict(
         result["shelved_goals"] = len(complete.shelf)
     if complete and complete.given_up:
         result["given_up_goals"] = len(complete.given_up)
+    depth = _focus_depth(complete)
+    if depth is not None:
+        result["focus_depth"] = depth
     if proof_finished and state_id is not None:
         path = _reconstruct_tactic_path(state_id)
         if path.status == "complete":
@@ -2037,6 +2069,9 @@ async def run_step_multi(
                     entry_dict["shelved_goals"] = len(complete.shelf)
                 if complete and complete.given_up:
                     entry_dict["given_up_goals"] = len(complete.given_up)
+                depth = _focus_depth(complete)
+                if depth is not None:
+                    entry_dict["focus_depth"] = depth
             except PetanqueError as e:
                 # If pet died, re-raise so outer handler detects it.
                 if not _server._pet_alive(lifespan_state.get("pet_client")):

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -2507,9 +2507,10 @@ async def rocq_step_multi(
       tactics=["destruct n.", "induction n.", "case_eq n."]
 
     Each result entry includes a ``feedback`` field (truncated string)
-    when the tactic produces visible output (e.g., ``Print``, ``Search``),
-    and a ``focus_depth`` field — how many ``{...}`` / bullet focus frames
-    that tactic leaves open above the goal (0 at the top level).
+    when the tactic produces visible output (e.g., ``Print``, ``Search``).
+    Each *successful* entry also carries a ``focus_depth`` field — how
+    many ``{...}`` / bullet focus frames that tactic leaves open above
+    the goal (0 at the top level).
 
     **Canonical exploration pattern:** if the first few steps of a proof
     are a confident prefix, advance with ``rocq_check`` first and pass
@@ -2598,10 +2599,12 @@ async def rocq_check(
     as a list of ``[command, output]`` pairs (truncated per step at 50K
     chars).  Omitted when no command produces output.
 
-    Every success response carries ``focus_depth`` — how many ``{...}`` /
-    bullet focus frames are currently open above the goal (0 at the top
-    level) — so an agent stepping through nested subgoals can tell how
-    deep it is and whether a ``}`` is still owed.
+    When proof goals are available, the success response carries
+    ``focus_depth`` — how many ``{...}`` / bullet focus frames are
+    currently open above the goal (0 at the top level) — so an agent
+    stepping through nested subgoals can tell how deep its focus nesting
+    is.  (Omitted on empty-body checks and when goal state cannot be
+    retrieved, like the other goal-derived fields.)
 
     **Note:** If the underlying .v file is modified after rocq_start, the
     session state becomes stale. A ``stale_warning`` field is returned when

--- a/src/rocq_mcp/server.py
+++ b/src/rocq_mcp/server.py
@@ -2361,6 +2361,10 @@ async def rocq_start(
     Returns a state_id for use with rocq_check and rocq_step_multi.
     Also returns the current proof goals at the starting position,
     so this tool can be used to inspect goals at any point in a file.
+    For a position inside a proof, the response also carries
+    ``focus_depth`` — how many ``{...}`` / bullet focus frames are open
+    above the goal (0 at the top level) — so a session resumed mid-proof
+    knows its bullet nesting (omitted for preamble-only starts).
 
     Three start modes (precedence: theorem > position > preamble):
     1. By theorem: file + theorem — start proving a specific theorem.
@@ -2503,7 +2507,9 @@ async def rocq_step_multi(
       tactics=["destruct n.", "induction n.", "case_eq n."]
 
     Each result entry includes a ``feedback`` field (truncated string)
-    when the tactic produces visible output (e.g., ``Print``, ``Search``).
+    when the tactic produces visible output (e.g., ``Print``, ``Search``),
+    and a ``focus_depth`` field — how many ``{...}`` / bullet focus frames
+    that tactic leaves open above the goal (0 at the top level).
 
     **Canonical exploration pattern:** if the first few steps of a proof
     are a confident prefix, advance with ``rocq_check`` first and pass
@@ -2591,6 +2597,11 @@ async def rocq_check(
     ``vm_compute``, ``native_compute``), a ``feedback`` field is included
     as a list of ``[command, output]`` pairs (truncated per step at 50K
     chars).  Omitted when no command produces output.
+
+    Every success response carries ``focus_depth`` — how many ``{...}`` /
+    bullet focus frames are currently open above the goal (0 at the top
+    level) — so an agent stepping through nested subgoals can tell how
+    deep it is and whether a ``}`` is still owed.
 
     **Note:** If the underlying .v file is modified after rocq_start, the
     session state becomes stale. A ``stale_warning`` field is returned when

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -740,6 +740,71 @@ class TestCheckProofTactics:
 
 
 # ---------------------------------------------------------------------------
+# TestCheckFocusDepth: focus_depth tracks bullet/brace nesting (real pet)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFocusDepth:
+    """focus_depth on rocq_check reflects the live focus-stack nesting."""
+
+    @pytest.mark.asyncio
+    async def test_focus_depth_rises_in_brace_and_falls_after(
+        self, workspace, lifespan_state
+    ):
+        """Entering `{` deepens focus; `}` returns to the prior depth."""
+        from rocq_mcp.interactive import run_start, run_check
+
+        vfile = workspace / "focus_depth.v"
+        vfile.write_text(
+            "Theorem t : True /\\ True.\n"
+            "Proof. split.\n"
+            "{ exact I. }\n"
+            "exact I.\n"
+            "Qed.\n"
+        )
+
+        sr = await run_start(
+            file=str(vfile.relative_to(workspace)),
+            theorem="t",
+            workspace=str(workspace),
+            lifespan_state=lifespan_state,
+        )
+        assert sr["success"] is True
+        # Fresh proof, no open bullets/braces yet.
+        assert sr["focus_depth"] == 0
+
+        # Two subgoals after split, still unfocused.
+        after_split = await run_check(
+            body="split.",
+            timeout=30.0,
+            lifespan_state=lifespan_state,
+            from_state=sr["state_id"],
+        )
+        assert after_split["success"] is True
+        base_depth = after_split["focus_depth"]
+
+        # Focusing the first subgoal pushes the rest onto the stack.
+        focused = await run_check(
+            body="{",
+            timeout=30.0,
+            lifespan_state=lifespan_state,
+            from_state=after_split["state_id"],
+        )
+        assert focused["success"] is True
+        assert focused["focus_depth"] > base_depth
+
+        # Closing the brace unfocuses, returning to the prior depth.
+        closed = await run_check(
+            body="exact I. }",
+            timeout=30.0,
+            lifespan_state=lifespan_state,
+            from_state=focused["state_id"],
+        )
+        assert closed["success"] is True
+        assert closed["focus_depth"] == base_depth
+
+
+# ---------------------------------------------------------------------------
 # TestCheckMultiCommandTimeout: per-command Rocq timeout (TL-2)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_focus_depth.py
+++ b/tests/test_focus_depth.py
@@ -50,11 +50,6 @@ class TestFocusDepthHelper:
 
         assert _focus_depth(_fake_goals(3)) == 3
 
-    def test_missing_stack_attr_is_zero(self):
-        from rocq_mcp.interactive import _focus_depth
-
-        assert _focus_depth(SimpleNamespace(stack=None)) == 0
-
 
 class TestGoalsWithDepth:
     """``_try_get_goals_with_depth`` backs the rocq_start builders."""

--- a/tests/test_focus_depth.py
+++ b/tests/test_focus_depth.py
@@ -1,0 +1,134 @@
+"""Tests for ``focus_depth`` on interactive responses.
+
+``focus_depth`` = ``len(complete_goals(state).stack)`` — how many ``{...}`` /
+bullet focus frames are open above the currently focused goal.  It rides on
+every ``rocq_check`` / ``rocq_step_multi`` / ``rocq_start`` success response so
+an agent stepping through nested bullets can see how deep it is.
+
+These are mock-based and run without ``pet``; real-pet behaviour (depth rises
+after ``{`` / a bullet, falls after ``}``) is exercised by the pet-gated
+integration test in ``test_check.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import _MockPetBase
+
+
+def _fake_goals(stack_depth: int, n_goals: int = 1) -> SimpleNamespace:
+    """A fake ``complete_goals`` result with *stack_depth* focus frames."""
+    return SimpleNamespace(
+        goals=[SimpleNamespace(hyps=[], ty="G") for _ in range(n_goals)],
+        stack=[([], []) for _ in range(stack_depth)],
+        shelf=[],
+        given_up=[],
+    )
+
+
+class TestFocusDepthHelper:
+    """Unit tests for the ``_focus_depth`` pure helper."""
+
+    pytestmark = []
+
+    def test_none_complete_returns_none(self):
+        from rocq_mcp.interactive import _focus_depth
+
+        assert _focus_depth(None) is None
+
+    def test_flat_context_is_zero(self):
+        from rocq_mcp.interactive import _focus_depth
+
+        assert _focus_depth(_fake_goals(0)) == 0
+
+    def test_counts_stack_frames(self):
+        from rocq_mcp.interactive import _focus_depth
+
+        assert _focus_depth(_fake_goals(3)) == 3
+
+    def test_missing_stack_attr_is_zero(self):
+        from rocq_mcp.interactive import _focus_depth
+
+        assert _focus_depth(SimpleNamespace(stack=None)) == 0
+
+
+class TestGoalsWithDepth:
+    """``_try_get_goals_with_depth`` backs the rocq_start builders."""
+
+    pytestmark = []
+
+    def test_returns_depth_alongside_goals(self):
+        from rocq_mcp.interactive import _try_get_goals_with_depth
+
+        mock_pet = MagicMock()
+        mock_pet.complete_goals.return_value = _fake_goals(2)
+        _text, depth = _try_get_goals_with_depth(mock_pet, object())
+        assert depth == 2
+
+    def test_failure_returns_none_none(self):
+        from rocq_mcp.interactive import _try_get_goals_with_depth
+
+        mock_pet = MagicMock()
+        mock_pet.complete_goals.side_effect = RuntimeError("boom")
+        assert _try_get_goals_with_depth(mock_pet, object()) == (None, None)
+
+
+class TestFocusDepthCheck(_MockPetBase):
+    """``focus_depth`` on the ``run_check`` success envelope."""
+
+    @pytest.mark.asyncio
+    async def test_check_reports_focus_depth(self):
+        import rocq_mcp.server as srv
+        import rocq_mcp.interactive as _interactive
+
+        new_state = SimpleNamespace(st=43, proof_finished=False, feedback=[])
+
+        def fake_run(state, cmd, timeout=None):
+            return new_state
+
+        sid, mock_pet, lifespan_state = self._setup_state_and_pet(fake_run)
+        mock_pet.complete_goals.return_value = _fake_goals(2)
+
+        with patch.object(srv, "_ensure_pet", return_value=mock_pet):
+            result = await _interactive.run_check(
+                body="intros.",
+                lifespan_state=lifespan_state,
+                from_state=sid,
+            )
+
+        assert result["success"] is True
+        assert result["focus_depth"] == 2
+
+
+class TestFocusDepthStepMulti(_MockPetBase):
+    """``focus_depth`` on each ``run_step_multi`` per-tactic entry."""
+
+    @pytest.mark.asyncio
+    async def test_step_multi_reports_focus_depth_per_entry(self):
+        import rocq_mcp.server as srv
+        import rocq_mcp.interactive as _interactive
+
+        new_state = SimpleNamespace(st=43, proof_finished=False, feedback=[])
+
+        def fake_run(state, cmd, timeout=None):
+            return new_state
+
+        sid, mock_pet, lifespan_state = self._setup_state_and_pet(fake_run)
+        mock_pet.complete_goals.return_value = _fake_goals(1)
+
+        with patch.object(srv, "_ensure_pet", return_value=mock_pet):
+            result = await _interactive.run_step_multi(
+                tactics=["intros.", "auto."],
+                lifespan_state=lifespan_state,
+                from_state=sid,
+            )
+
+        assert result["success"] is True
+        assert len(result["results"]) == 2
+        for entry in result["results"]:
+            assert entry["success"] is True
+            assert entry["focus_depth"] == 1


### PR DESCRIPTION
When rocq_check is called with a body consisting of exactly one bullet/focus-management token ({, }, or a run of -/+/*), the response now includes focus_command, goals_before, goals_after, focus_depth_before, and focus_depth_after so the agent can see the focus transition rather than an empty goals string.